### PR TITLE
date check never should happen when use greatest is enabled

### DIFF
--- a/updates.js
+++ b/updates.js
@@ -345,8 +345,10 @@ function findNewVersion(data, opts) {
     if (!opts.semvers.includes(diff)) continue;
     if (diff === "prerelease" && !opts.usePre) continue;
 
-    if (opts.useGreatest && semver.gte(parsed.version, tempVersion)) {
-      tempVersion = parsed.version;
+    if (opts.useGreatest) {
+      if (semver.gte(parsed.version, tempVersion)) {
+        tempVersion = parsed.version;
+      }
     } else {
       const date = (new Date(data.time[version])).getTime();
       if (date >= 0 && date > tempDate) {


### PR DESCRIPTION
use greatest did not work when some patch release happend after some major release

e.g a 4 weeks old 4.0.0 release and a 5 days old 3.5.1 

this is because semver.gte return false and so the else block gets exectued.
which then updates tempVersion to 3.5.1 since it is not as old as 4.0.0