### PR TITLE
Closes #34

### DIFF
--- a/updates.js
+++ b/updates.js
@@ -538,6 +538,7 @@ function findNewVersion(data, opts) {
 
 async function checkUrlDep([key, dep], {useGreatest} = {}) {
   const stripped = dep.old.replace(stripRe, "");
+  if (typeof stripped !== "array") return;
   const [_, user, repo, oldRef] = partsRe.exec(stripped);
   if (!user || !repo || !oldRef) return;
 


### PR DESCRIPTION
Error described in #34 no longer occurs but I don't know if this fix breaks something else. In my initial test, no.