### PR TITLE
[experimental] Prefer bun runtime via polyglot hashbang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,9 @@ bench: node_modules build
 .PHONY: build
 build: node_modules $(DIST_FILES)
 
-$(DIST_FILES): $(SOURCE_FILES) pnpm-lock.yaml tsdown.config.ts
+$(DIST_FILES): $(SOURCE_FILES) pnpm-lock.yaml tsdown.config.ts shebang
 	pnpm exec tsdown
+	{ cat shebang; tail -n +2 dist/index.js; } > dist/index.js.tmp && mv dist/index.js.tmp dist/index.js
 	chmod +x $(DIST_FILES)
 
 .PHONY: update

--- a/index.test.ts
+++ b/index.test.ts
@@ -412,6 +412,18 @@ test("jsr", async ({expect = globalExpect}: any = {}) => {
   expect(results.npm.devDependencies["@std/path"].new).toBe("1.0.8");
 });
 
+test("bin -v", async ({expect = globalExpect}: any = {}) => {
+  const pkg = JSON.parse(readFileSync(fileURLToPath(new URL("package.json", import.meta.url)), "utf8"));
+  const viaRuntime = await execFileAsync(execPath, [script, "-v"]);
+  expect(viaRuntime.stderr).toEqual("");
+  expect(viaRuntime.stdout.trim()).toEqual(pkg.version);
+  if (platform !== "win32") {
+    const viaShebang = await execFileAsync(script, ["-v"]);
+    expect(viaShebang.stderr).toEqual("");
+    expect(viaShebang.stdout.trim()).toEqual(pkg.version);
+  }
+});
+
 if (!versions.bun) {
   test("global", async ({expect = globalExpect}: any = {}) => {
     const prefix = mkdtempSync(join(tmpdir(), "updates-global-"));

--- a/shebang
+++ b/shebang
@@ -1,0 +1,5 @@
+#!/bin/sh
+':' /*
+command -v bun >/dev/null 2>&1 && exec bun "$0" "$@"
+exec node "$0" "$@"
+*/


### PR DESCRIPTION
Replaces the `#!/usr/bin/env node` shebang in `dist/index.js` with a polyglot shell/JS block that prefers `bun` and falls back to `node`.

## How it works

```sh
#!/bin/sh
':' /*
command -v bun >/dev/null 2>&1 && exec bun "$0" "$@"
exec node "$0" "$@"
*/
```

- Kernel runs `/bin/sh` on the file
- `:` is the sh no-op, silently ignoring the glob expansion of `/*`
- If `bun` is on `PATH`, `exec bun` replaces the shell; otherwise `exec node`
- Node/Bun strip the shebang line, then see `':'` (string expr) followed by a block comment — valid JS

Injected into `dist/index.js` post-tsdown via a Makefile step so the minifier can't collapse it. The new `shebang` file at the repo root holds the literal contents.

## Measured impact (`updates -v`, hyperfine 50 runs)

| Platform | node | bun | polyglot |
|---|---|---|---|
| macOS (arm64, Homebrew node) | 114.4 ms | 53.6 ms | **57.3 ms** (~2.0×) |
| Linux (Debian x64, docker) | 19.5 ms | 17.4 ms | **20.1 ms** (~neutral) |
| Windows | — | — | shebangs ignored |

The big macOS win comes from Homebrew node being a 68 KB dyld shim that loads 23 dylibs on every invocation (per-dylib code signature validation). Statically-linked node (e.g. nodejs.org) wouldn't see the same gap.

## Test

Adds a smoke test for `updates -v` (`index.test.ts`):
- Invokes via `execPath` so the test exercises whichever runtime CI launched (node or bun)
- Invokes directly via the shebang on non-Windows
- Windows skips the shebang path

The existing CI matrix (node 22, node 24, bun latest × ubuntu/macos/windows) already covers all interesting combinations — no workflow changes.

## Why experimental

- Relies on `/bin/sh` being available, which rules out Windows by design
- Adds a post-build step (not ideal; ideally tsdown/rolldown would bypass minification of the hashbang line)
- Bun's proposed `engines.bun` → auto-rewrite (oven-sh/bun#9346) is still unshipped; this is a workaround until then

Happy to close if the approach is the wrong direction.

---
This PR was written with the help of Claude Opus 4.6