### PR TITLE
Cooldown picks an older eligible version instead of dropping the dep

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -6,14 +6,14 @@ import {readFile} from "node:fs/promises";
 import {parseToml} from "./utils/toml.ts";
 import {valid, validRange} from "./utils/semver.ts";
 import {timerel} from "timerel";
-import {npmTypes, uvTypes, goTypes, cargoTypes, parseUvDependencies, nonPackageEngines, parseDuration, matchesAny, getProperty, canIncludeByDate, timestamp, pMap} from "./utils/utils.ts";
+import {npmTypes, uvTypes, goTypes, cargoTypes, parseUvDependencies, nonPackageEngines, parseDuration, matchesAny, getProperty, timestamp, pMap} from "./utils/utils.ts";
 import {enableDnsCache} from "./utils/dns.ts";
 import {
   type Dep, type Deps, type DepsByMode, type Output, type ModeContext,
   type PackageRepository, type PackageInfo,
   fieldSep, normalizeUrl, fetchTimeout, goProbeTimeout,
   doFetch, findVersion, findNewVersion, coerceToVersion, getInfoUrl, getGithubTokens,
-  stripv, hashRe as npmHashRe,
+  passesCooldown, stripv, hashRe as npmHashRe,
 } from "./modes/shared.ts";
 import {loadConfig, configMixedToRegexes, patternsToRegexSet} from "./config.ts";
 import type {Config} from "./config.ts";
@@ -90,15 +90,6 @@ function setDepAge(dep: Dep, date: string): void {
   if (date) {
     dep.date = date;
     dep.age = timerel(date, {noAffix: true});
-  }
-}
-
-function applyCooldown(modeDeps: Deps, cooldown: string | number, now: number): void {
-  const days = parseDuration(String(cooldown));
-  for (const [key, {date}] of Object.entries(modeDeps)) {
-    if (!canIncludeByDate(date, days, now)) {
-      delete modeDeps[key];
-    }
   }
 }
 
@@ -727,6 +718,17 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
     const {modeConfig, projectDir, pin} = modeConfigs[mode];
     fetchTasks.push((async () => {
       const npmFollowUps = new Map<string, {name: string, promise: Promise<{repository?: PackageRepository, homepage?: string, date?: string}>}>();
+      const cooldownRaw = config.cooldown ?? modeConfig.cooldown;
+      const cooldownDays = cooldownRaw ? parseDuration(String(cooldownRaw)) : 0;
+      // Safety net for deps that bypass findNewVersion (URL tarballs, JSR
+      // follow-ups). findNewVersion's per-version cooldown filter handles the
+      // common case; this catches the rest.
+      const dropIfTooNew = (modeDeps: Deps) => {
+        if (!cooldownDays) return;
+        for (const [k, {date}] of Object.entries(modeDeps)) {
+          if (date && (now - Date.parse(date)) / 86400000 < cooldownDays) delete modeDeps[k];
+        }
+      };
 
       await pMap(Object.keys(deps[mode]), async (key) => {
         const [type, name] = key.split(fieldSep);
@@ -765,6 +767,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
         const pinnedRange = pin[name];
         const newVersion = findNewVersion(data, {
           usePre, useRel, useGreatest, semvers, range: oldRange, mode, pinnedRange,
+          cooldownDays: cooldownDays || undefined, now: cooldownDays ? now : undefined,
         }, {allowDowngrade, matchesAny, isGoPseudoVersion});
 
         let newRange = "";
@@ -842,8 +845,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
         }
       }
 
-      const cooldown = config.cooldown ?? modeConfig.cooldown;
-      if (cooldown) applyCooldown(deps[mode], cooldown, now);
+      dropIfTooNew(deps[mode]);
     })());
   }
 
@@ -857,6 +859,8 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
         if (!entry) depsByRepo.set(repoKey, entry = {apiUrl: info.apiUrl, owner: info.owner, repo: info.repo, infos: []});
         entry.infos.push(info);
       }
+
+      const actionsCooldownDays = config.cooldown ? parseDuration(String(config.cooldown)) : 0;
 
       await pMap(depsByRepo.values(), async ({apiUrl, owner, repo, infos}) => {
         const tags = await fetchActionTags(apiUrl, owner, repo, ctx);
@@ -882,26 +886,42 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
           return date;
         }
 
-        const dateFetches: Array<{key: string, commitSha: string}> = [];
+        // Cooldown-aware selection: when cooldown is active, pick the highest
+        // version, fetch its commit date, and if it's too new, exclude it and
+        // retry. Bounded loop avoids pathological cases (e.g. all versions
+        // released within the cooldown window).
+        async function pickVersion(opts: Parameters<typeof findVersion>[2]): Promise<{version: string, tag: string, commitSha: string, date: string} | null> {
+          const denylist = new Set<string>();
+          for (let attempt = 0; attempt < 20; attempt++) {
+            const candidates = denylist.size ? versions.filter(v => !denylist.has(v)) : versions;
+            const picked = findVersion({}, candidates, opts);
+            if (!picked || picked === opts.range) return null;
+            const tag = tagByStripped.get(picked);
+            if (!tag) { denylist.add(picked); continue; }
+            const commitSha = entryByName.get(tag)?.commitSha || "";
+            if (!actionsCooldownDays) return {version: picked, tag, commitSha, date: ""};
+            const date = commitSha ? await getDate(commitSha) : "";
+            if (passesCooldown(date, actionsCooldownDays, now)) return {version: picked, tag, commitSha, date};
+            denylist.add(picked);
+          }
+          return null;
+        }
 
-        for (const {key, host, ref, name: actionName, isHash} of infos) {
+        await pMap(infos, async ({key, host, ref, name: actionName, isHash}) => {
           const dep = deps.actions[key];
           const infoUrl = `https://${host || "github.com"}/${owner}/${repo}`;
 
           if (isHash) {
             const {usePre, useRel} = getVersionOpts(actionName);
-            const newVersion = findVersion({}, versions, {
+            const result = await pickVersion({
               range: "0.0.0", semvers: new Set(["patch", "minor", "major"]), usePre, useRel,
               useGreatest: true, pinnedRange: configPin[actionName],
             });
-            if (!newVersion) { delete deps.actions[key]; continue; }
+            if (!result) { delete deps.actions[key]; return; }
 
-            const newTag = tagByStripped.get(newVersion);
-            if (!newTag) { delete deps.actions[key]; continue; }
-
-            const newCommitSha = entryByName.get(newTag)?.commitSha;
+            const {tag: newTag, commitSha: newCommitSha, date} = result;
             if (!newCommitSha || newCommitSha === ref || newCommitSha.startsWith(ref) || ref.startsWith(newCommitSha)) {
-              delete deps.actions[key]; continue;
+              delete deps.actions[key]; return;
             }
 
             let oldTagName = commitShaToTag.get(ref);
@@ -915,43 +935,33 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
             dep.oldPrint = oldTagName || ref.substring(0, 7);
             dep.newPrint = newTag;
             dep.info = infoUrl;
-
-            dateFetches.push({key, commitSha: newCommitSha});
+            if (date) setDepAge(dep, date);
           } else {
             const coerced = coerceToVersion(stripv(ref));
-            if (!coerced) { delete deps.actions[key]; continue; }
+            if (!coerced) { delete deps.actions[key]; return; }
 
             const {useGreatest, usePre, useRel, semvers} = getVersionOpts(actionName);
-            const newVersion = findVersion({}, versions, {
+            const result = await pickVersion({
               range: coerced, semvers, usePre, useRel,
               useGreatest: useGreatest || true, pinnedRange: configPin[actionName],
             });
-            if (!newVersion || newVersion === coerced) { delete deps.actions[key]; continue; }
+            if (!result) { delete deps.actions[key]; return; }
 
-            const newTag = tagByStripped.get(newVersion);
-            if (!newTag) { delete deps.actions[key]; continue; }
-
+            const {tag: newTag, commitSha: newCommitSha, date} = result;
             const formatted = formatActionVersion(newTag, ref);
-            if (formatted === ref) { delete deps.actions[key]; continue; }
+            if (formatted === ref) { delete deps.actions[key]; return; }
 
             dep.new = entryByName.has(formatted) ? formatted : newTag;
             dep.info = infoUrl;
-
-            const newCommitSha = entryByName.get(newTag)?.commitSha;
-            if (newCommitSha) {
-              dateFetches.push({key, commitSha: newCommitSha});
+            if (newCommitSha && date) setDepAge(dep, date);
+            else if (newCommitSha) {
+              const fetched = await getDate(newCommitSha);
+              if (fetched) setDepAge(dep, fetched);
             }
           }
-        }
-
-        const dates = await Promise.all(dateFetches.map(({commitSha}) => getDate(commitSha)));
-        for (const [idx, {key}] of dateFetches.entries()) {
-          const dep = deps.actions[key];
-          if (dep && dates[idx]) setDepAge(dep, dates[idx]);
-        }
+        }, {concurrency});
       }, {concurrency});
 
-      if (config.cooldown) applyCooldown(deps.actions, config.cooldown, now);
       if (!Object.keys(deps.actions).length) delete deps.actions;
     })());
   }
@@ -965,6 +975,8 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
         if (!list) depsByImage.set(info.fullImage, list = []);
         list.push(info);
       }
+
+      const dockerCooldownDays = config.cooldown ? parseDuration(String(config.cooldown)) : 0;
 
       await pMap(depsByImage.entries(), async ([fullImage, infos]) => {
         let data: Record<string, any>;
@@ -980,7 +992,10 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
           const dep = deps.docker[info.key];
           const oldTag = dep.oldOrig || dep.old;
           const {semvers} = getVersionOpts(info.fullImage);
-          const result = findDockerVersion(data.tags, oldTag, semvers);
+          const result = findDockerVersion(
+            data.tags, oldTag, semvers,
+            dockerCooldownDays || undefined, dockerCooldownDays ? now : undefined,
+          );
           if (!result) { delete deps.docker[info.key]; continue; }
 
           dep.new = result.newTag;
@@ -989,7 +1004,6 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
         }
       }, {concurrency});
 
-      if (config.cooldown) applyCooldown(deps.docker, config.cooldown, now);
       if (!Object.keys(deps.docker).length) delete deps.docker;
     })());
   }

--- a/modes/docker.ts
+++ b/modes/docker.ts
@@ -1,5 +1,5 @@
 import {coerce, diff, gte} from "../utils/semver.ts";
-import {type Deps, type ModeContext, type PackageInfo, fieldSep, fetchWithEtag, stripv, formatVersionPrecision} from "./shared.ts";
+import {type Deps, type ModeContext, type PackageInfo, fieldSep, fetchWithEtag, passesCooldown, stripv, formatVersionPrecision} from "./shared.ts";
 import {esc} from "../utils/utils.ts";
 
 export type DockerImageRef = {
@@ -128,6 +128,8 @@ export function findDockerVersion(
   tagMap: Record<string, string>,
   oldTag: string,
   semvers: Set<string>,
+  cooldownDays?: number,
+  now?: number,
 ): {newTag: string, date: string} | null {
   const oldParsed = parseDockerTag(oldTag);
   if (!oldParsed) return null;
@@ -145,6 +147,8 @@ export function findDockerVersion(
 
     const coerced = coerce(stripv(parsed.version))?.version;
     if (!coerced) continue;
+
+    if (!passesCooldown(lastUpdated, cooldownDays, now)) continue;
 
     const d = diff(bestVersion, coerced);
     if (!d || !semvers.has(d)) continue;

--- a/modes/shared.test.ts
+++ b/modes/shared.test.ts
@@ -381,6 +381,72 @@ test("findVersion skips prereleases when usePre=false", () => {
   expect(result).toBe("1.1.0");
 });
 
+test("findVersion cooldown picks older eligible version", () => {
+  const now = Date.parse("2026-04-25T00:00:00Z");
+  const data = {
+    versions: {"1.0.0": {}, "1.1.0": {}, "1.2.0": {}, "1.3.0": {}},
+    time: {
+      "1.0.0": "2026-01-01T00:00:00Z",
+      "1.1.0": "2026-04-10T00:00:00Z", // 15 days old — eligible
+      "1.2.0": "2026-04-22T00:00:00Z", // 3 days old — too new
+      "1.3.0": "2026-04-24T00:00:00Z", // 1 day old — too new
+    },
+  };
+  const result = findVersion(data, ["1.0.0", "1.1.0", "1.2.0", "1.3.0"], {
+    range: "1.0.0",
+    semvers: new Set(["major", "minor", "patch"]),
+    usePre: false,
+    useRel: false,
+    useGreatest: true,
+    cooldownDays: 5,
+    now,
+  });
+  expect(result).toBe("1.1.0");
+});
+
+test("findVersion cooldown returns no upgrade when all candidates too new", () => {
+  const now = Date.parse("2026-04-25T00:00:00Z");
+  const data = {
+    versions: {"1.1.0": {}, "1.2.0": {}},
+    time: {
+      "1.1.0": "2026-04-23T00:00:00Z",
+      "1.2.0": "2026-04-24T00:00:00Z",
+    },
+  };
+  const result = findVersion(data, ["1.1.0", "1.2.0"], {
+    range: "1.0.0",
+    semvers: new Set(["major", "minor", "patch"]),
+    usePre: false,
+    useRel: false,
+    useGreatest: true,
+    cooldownDays: 5,
+    now,
+  });
+  expect(result).toBe("1.0.0");
+});
+
+test("findNewVersion npm cooldown picks older eligible version", () => {
+  const now = Date.parse("2026-04-25T00:00:00Z");
+  const data = {
+    name: "pkg",
+    "dist-tags": {latest: "1.3.0"},
+    versions: {"1.0.0": {}, "1.1.0": {}, "1.2.0": {}, "1.3.0": {}},
+    time: {
+      "1.0.0": "2026-01-01T00:00:00Z",
+      "1.1.0": "2026-04-10T00:00:00Z",
+      "1.2.0": "2026-04-22T00:00:00Z",
+      "1.3.0": "2026-04-24T00:00:00Z",
+    },
+  };
+  const result = findNewVersion(data, {
+    mode: "npm", range: "1.0.0",
+    semvers: new Set(["major", "minor", "patch"]),
+    usePre: false, useRel: false, useGreatest: false,
+    cooldownDays: 5, now,
+  }, {allowDowngrade: false, matchesAny: () => false, isGoPseudoVersion: () => false});
+  expect(result).toBe("1.1.0");
+});
+
 test("getInfoUrl string repository URL", () => {
   const result = getInfoUrl({repository: "https://github.com/user/repo"}, null, "pkg");
   expect(result).toBe("https://github.com/user/repo");

--- a/modes/shared.ts
+++ b/modes/shared.ts
@@ -35,6 +35,16 @@ export type Output = {
   message?: string,
 };
 
+export type CooldownOpts = {
+  cooldownDays?: number,
+  now?: number,
+  // Returns ISO date string for a given version, or undefined if unknown.
+  // When undefined is returned, the version is treated as eligible (we cannot
+  // prove it is too new) — callers must not pass this for ecosystems where
+  // missing data should mean "skip".
+  getVersionDate?: (version: string) => string | undefined,
+};
+
 export type FindVersionOpts = {
   range: string,
   semvers: Set<string>,
@@ -42,7 +52,7 @@ export type FindVersionOpts = {
   useRel: boolean,
   useGreatest: boolean,
   pinnedRange?: string,
-};
+} & CooldownOpts;
 
 export type FindNewVersionOpts = {
   mode: string,
@@ -52,7 +62,16 @@ export type FindNewVersionOpts = {
   useGreatest: boolean,
   semvers: Set<string>,
   pinnedRange?: string,
-};
+} & CooldownOpts;
+
+// Returns true if the given ISO date is at least cooldownDays old (inclusive)
+// relative to `now`. Missing date or inactive cooldown returns true.
+export function passesCooldown(date: string | undefined, cooldownDays: number | undefined, now: number | undefined): boolean {
+  if (!cooldownDays || !now || !date) return true;
+  const ms = Date.parse(date);
+  if (Number.isNaN(ms)) return true;
+  return (now - ms) / (24 * 3600 * 1000) >= cooldownDays;
+}
 
 export type PackageInfo = [Record<string, any>, string, string | null, string];
 
@@ -188,7 +207,7 @@ export function coerceToVersion(rangeOrVersion: string): string {
   return coerce(rangeOrVersion)?.version ?? "";
 }
 
-export function findVersion(data: any, versions: Array<string>, {range, semvers, usePre, useRel, useGreatest, pinnedRange}: FindVersionOpts): string | null {
+export function findVersion(data: any, versions: Array<string>, {range, semvers, usePre, useRel, useGreatest, pinnedRange, cooldownDays, now, getVersionDate}: FindVersionOpts): string | null {
   const oldVersion = coerceToVersion(range);
   if (!oldVersion) return oldVersion;
 
@@ -201,6 +220,8 @@ export function findVersion(data: any, versions: Array<string>, {range, semvers,
     if (semvers.has("major")) semvers.add("premajor");
   }
 
+  const lookupDate = getVersionDate ?? ((v: string) => data?.time?.[v]);
+
   let greatestDate = 0;
   let newVersion = oldVersion;
 
@@ -211,6 +232,8 @@ export function findVersion(data: any, versions: Array<string>, {range, semvers,
 
     // If a pinned range is specified, only consider versions that satisfy it
     if (pinnedRange && !satisfies(candidateVersion, pinnedRange)) continue;
+
+    if (!passesCooldown(lookupDate(version), cooldownDays, now)) continue;
 
     const d = diff(newVersion, candidateVersion);
     if (!d || !semvers.has(d)) continue;
@@ -233,15 +256,18 @@ export function findVersion(data: any, versions: Array<string>, {range, semvers,
   return newVersion || null;
 }
 
-export function findNewVersion(data: any, {mode, range, useGreatest, useRel, usePre, semvers, pinnedRange}: FindNewVersionOpts, {allowDowngrade, matchesAny, isGoPseudoVersion}: {allowDowngrade: Set<RegExp> | boolean, matchesAny: (str: string, set: Set<RegExp> | boolean) => boolean, isGoPseudoVersion: (version: string) => boolean}): string | null {
+export function findNewVersion(data: any, {mode, range, useGreatest, useRel, usePre, semvers, pinnedRange, cooldownDays, now}: FindNewVersionOpts, {allowDowngrade, matchesAny, isGoPseudoVersion}: {allowDowngrade: Set<RegExp> | boolean, matchesAny: (str: string, set: Set<RegExp> | boolean) => boolean, isGoPseudoVersion: (version: string) => boolean}): string | null {
   if (range === "*") return null; // ignore wildcard
   if (range.includes("||")) return null; // ignore or-chains
 
   let versions: Array<string> = [];
+  let getVersionDate: ((v: string) => string | undefined) | undefined;
   if (mode === "pypi") {
     versions = Object.keys(data.releases).filter(v => valid(v));
+    getVersionDate = (v: string) => data.releases?.[v]?.[0]?.upload_time_iso_8601;
   } else if (mode === "npm" || mode === "cargo") {
     versions = Object.keys(data.versions).filter(v => valid(v));
+    getVersionDate = (v: string) => data.time?.[v];
   } else if (mode === "go") {
     const oldVersion = coerceToVersion(range);
     if (!oldVersion) return null;
@@ -255,7 +281,8 @@ export function findNewVersion(data: any, {mode, range, useGreatest, useRel, use
     const crossVersion = coerceToVersion(data.new);
     if (crossVersion && !isGoPseudoVersion(data.new) && !skipPrerelease(data.new)) {
       const d = diff(oldVersion, crossVersion);
-      if (d && semvers.has(d) && isAllowedVersionTransition(originalOldVersion, data.new, transitionOpts)) {
+      if (d && semvers.has(d) && isAllowedVersionTransition(originalOldVersion, data.new, transitionOpts) &&
+          passesCooldown(data.Time, cooldownDays, now)) {
         return data.new;
       }
     }
@@ -264,16 +291,31 @@ export function findNewVersion(data: any, {mode, range, useGreatest, useRel, use
     const sameVersion = coerceToVersion(data.sameMajorNew);
     if (sameVersion && !isGoPseudoVersion(data.sameMajorNew) && !skipPrerelease(data.sameMajorNew)) {
       const d = diff(oldVersion, sameVersion);
-      if (d && semvers.has(d) && isAllowedVersionTransition(originalOldVersion, data.sameMajorNew, transitionOpts)) {
+      if (d && semvers.has(d) && isAllowedVersionTransition(originalOldVersion, data.sameMajorNew, transitionOpts) &&
+          passesCooldown(data.sameMajorTime, cooldownDays, now)) {
         data.Time = data.sameMajorTime;
         delete data.newPath;
         return data.sameMajorNew;
       }
     }
 
+    // If cooldown gated the resolved versions, fall back to a proxy walk to
+    // find an older eligible version. Otherwise no upgrade is available.
+    if (cooldownDays && now && data.olderEligible && !skipPrerelease(data.olderEligible.version)) {
+      const v = coerceToVersion(data.olderEligible.version);
+      if (v) {
+        const d = diff(oldVersion, v);
+        if (d && semvers.has(d) && isAllowedVersionTransition(originalOldVersion, data.olderEligible.version, transitionOpts)) {
+          data.Time = data.olderEligible.time;
+          delete data.newPath;
+          return data.olderEligible.version;
+        }
+      }
+    }
+
     return null;
   }
-  const version = findVersion(data, versions, {range, semvers, usePre, useRel, useGreatest, pinnedRange});
+  const version = findVersion(data, versions, {range, semvers, usePre, useRel, useGreatest, pinnedRange, cooldownDays, now, getVersionDate});
   if (!version) return null;
 
   if (useGreatest) {
@@ -331,6 +373,17 @@ export function findNewVersion(data: any, {mode, range, useGreatest, useRel, use
     // If a pinned range is specified and latestTag doesn't satisfy it, return version
     if (pinnedRange && !satisfies(latestTag, pinnedRange)) {
       return version;
+    }
+
+    // latestTag may be too new under cooldown — fall back to the
+    // already-filtered `version` selected by findVersion.
+    if (cooldownDays && now) {
+      const latestDate = mode === "pypi" ?
+        data.releases?.[originalLatestTag || latestTag]?.[0]?.upload_time_iso_8601 :
+        data.time?.[originalLatestTag || latestTag] ?? data.time?.[latestTag];
+      if (!passesCooldown(latestDate, cooldownDays, now)) {
+        return version;
+      }
     }
 
     // in all other cases, return latest dist-tag


### PR DESCRIPTION
**Problem.** The current `--cooldown N` is applied as a post-filter after picking the target version: if the latest is younger than N days, the dep is dropped from the run entirely. For a dep that releases every day with cooldown=5, the latest is always <5 days old, so the dep is never updated — it gets stuck on the version it was at when cooldown was first enabled.

**Behavior change.** Cooldown is now evaluated per-version inside the selection step (`findVersion`, `findNewVersion`, `findDockerVersion`). We pick the highest version that satisfies the range/semvers constraint AND is at least N days old. The dep still updates — it just lags ~N days behind head, matching how Renovate and Dependabot's cooldown work.

| Scenario (cooldown=5d) | Before | After |
| --- | --- | --- |
| Dep releases every day | never updates | updates to the version that's exactly 5 days old |
| Dep released v1.2.3 (10d ago) and v1.2.4 (2d ago) | dropped (latest too new) | picks v1.2.3 |
| Dep released v1.2.3 (10d ago), no newer | picks v1.2.3 | picks v1.2.3 (unchanged) |
| Dep released only v1.2.3 (2d ago) | dropped | dropped (no eligible older version) |

**Coverage.**
- npm, pypi, cargo, github-actions, docker — full per-version selection using existing date metadata (registry `time` map for npm/cargo, `releases[v][0].upload_time_iso_8601` for pypi, per-tag `last_updated` for docker, fetched commit dates for actions with iterative selection up to 20 attempts).
- Go modules — the proxy only exposes the resolved latest plus same-major latest. If both are too new, the dep is dropped (matches today's behavior, no regression). An `olderEligible` hook is plumbed into `findNewVersion` for a follow-up that walks `/@v/list` to find an older eligible version.

**Other notes.**
- A narrow post-filter remains in `api.ts` as a safety net for paths that bypass `findNewVersion` (URL tarball deps, JSR follow-ups whose date comes from version-specific publish info).
- New tests in `modes/shared.test.ts` cover: `findVersion` picking the older eligible version, returning no-upgrade when all candidates are too new, and `findNewVersion` npm picking via cooldown.
- All 453 tests pass; lint clean.

---
This PR was written with the help of Claude Opus 4.7