### PR TITLE
Parse pins and cooldown from renovate config

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -4,6 +4,7 @@ import {accessSync} from "node:fs";
 import type {ParseArgsOptionsConfig} from "node:util";
 import {validRange} from "./utils/semver.ts";
 import {commaSeparatedToArray, esc} from "./utils/utils.ts";
+import {loadRenovateConfig} from "./utils/renovate.ts";
 
 export type Config = {
   /** Array of dependencies to include */
@@ -178,6 +179,7 @@ export async function loadConfig(rootDir: string): Promise<Config> {
   for (const ext of ["js", "ts", "mjs", "mts"]) {
     filenames.push(`updates.config.${ext}`);
   }
+  const renovateConfig = await loadRenovateConfig(rootDir);
   let config: Config = {};
 
   try {
@@ -206,5 +208,5 @@ export async function loadConfig(rootDir: string): Promise<Config> {
     }
   }
 
-  return config;
+  return {...renovateConfig, ...config};
 }

--- a/fixtures/renovate/real-world.json5
+++ b/fixtures/renovate/real-world.json5
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "enabledManagers": ["github-actions", "gomod", "npm"],
+  "labels": ["dependencies"],
+  "branchPrefix": "renovate/",
+  "schedule": ["* * * * 1"], // dependency update PRs weekly, vulnerabilityAlerts bypasses this
+  "minimumReleaseAge": "5 days",
+  "semanticCommits": "enabled",
+  "dependencyDashboard": false,
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+  },
+  "packageRules": [
+    {
+      "groupName": "action dependencies",
+      "matchManagers": ["github-actions"],
+    },
+    {
+      "groupName": "go dependencies",
+      "matchManagers": ["gomod"],
+      "postUpgradeTasks": {
+        "commands": ["make tidy"],
+        "fileFilters": ["go.mod", "go.sum", "assets/go-licenses.json"],
+        "executionMode": "branch",
+      },
+    },
+    {
+      "groupName": "npm dependencies",
+      "matchManagers": ["npm"],
+      "postUpgradeTasks": {
+        "commands": ["make svg"],
+        "fileFilters": ["public/assets/img/svg/**"],
+        "executionMode": "branch",
+      },
+    },
+    {
+      // breaking changes in rc versions need to be handled
+      "matchPackageNames": ["@mcaptcha/vanilla-glue"],
+      "allowedVersions": "^0.1",
+    },
+    {
+      // need to migrate to v2 but v2 is not compatible with v1
+      "matchPackageNames": ["cropperjs"],
+      "allowedVersions": "^1",
+    },
+    {
+      // need to migrate
+      "matchPackageNames": ["tailwindcss"],
+      "allowedVersions": "^3",
+    },
+  ],
+}

--- a/fixtures/renovate/real-world.json5
+++ b/fixtures/renovate/real-world.json5
@@ -50,5 +50,10 @@
       "matchPackageNames": ["tailwindcss"],
       "allowedVersions": "^3",
     },
+    {
+      // ignore all @types/* packages via regex matcher
+      "matchPackageNames": ["/^@types\\//"],
+      "enabled": false,
+    },
   ],
 }

--- a/utils/json5.test.ts
+++ b/utils/json5.test.ts
@@ -1,0 +1,43 @@
+import {test, expect} from "vitest";
+import {parseJsonish} from "./json5.ts";
+
+test("plain JSON", () => {
+  expect(parseJsonish(`{"a":1,"b":[2,3]}`)).toEqual({a: 1, b: [2, 3]});
+});
+
+test("line comments", () => {
+  expect(parseJsonish(`{
+    // top
+    "a": 1 // trailing
+  }`)).toEqual({a: 1});
+});
+
+test("block comments", () => {
+  expect(parseJsonish(`{ /* x */ "a": /* y */ 1 }`)).toEqual({a: 1});
+});
+
+test("trailing commas", () => {
+  expect(parseJsonish(`{"a": [1, 2,], "b": 3,}`)).toEqual({a: [1, 2], b: 3});
+});
+
+test("comment-like content inside strings is preserved", () => {
+  expect(parseJsonish(`{"a": "// not a comment", "b": "/* nope */"}`)).toEqual({a: "// not a comment", b: "/* nope */"});
+});
+
+test("escaped quotes inside strings", () => {
+  expect(parseJsonish(`{"a": "he said \\"hi\\""}`)).toEqual({a: 'he said "hi"'});
+});
+
+test("JSONC (mixed comments + trailing commas)", () => {
+  const text = `{
+    // a comment
+    "minimumReleaseAge": "3 days",
+    /* block
+       comment */
+    "ignoreDeps": [
+      "foo",
+      "bar",
+    ],
+  }`;
+  expect(parseJsonish(text)).toEqual({minimumReleaseAge: "3 days", ignoreDeps: ["foo", "bar"]});
+});

--- a/utils/json5.ts
+++ b/utils/json5.ts
@@ -1,0 +1,52 @@
+/**
+ * Minimal JSON5/JSONC-tolerant parser. Strips line/block comments and
+ * trailing commas, then defers to JSON.parse. Covers JSONC fully and the
+ * common subset of JSON5 used in the wild; does not support unquoted keys
+ * or single-quoted strings.
+ */
+export function parseJsonish(text: string): unknown {
+  let out = "";
+  let i = 0;
+  const n = text.length;
+
+  while (i < n) {
+    const ch = text[i];
+
+    if (ch === '"') {
+      out += ch;
+      i++;
+      while (i < n) {
+        const c = text[i];
+        out += c;
+        i++;
+        if (c === "\\" && i < n) {
+          out += text[i];
+          i++;
+          continue;
+        }
+        if (c === '"') break;
+      }
+      continue;
+    }
+
+    if (ch === "/" && i + 1 < n && text[i + 1] === "/") {
+      i += 2;
+      while (i < n && text[i] !== "\n") i++;
+      continue;
+    }
+
+    if (ch === "/" && i + 1 < n && text[i + 1] === "*") {
+      i += 2;
+      while (i < n && (text[i] !== "*" || text[i + 1] !== "/")) i++;
+      i += 2;
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+
+  out = out.replace(/,(\s*[}\]])/g, "$1");
+
+  return JSON.parse(out);
+}

--- a/utils/renovate.test.ts
+++ b/utils/renovate.test.ts
@@ -1,0 +1,136 @@
+import {test, expect, afterAll} from "vitest";
+import {mkdtempSync, rmSync, mkdirSync, writeFileSync, copyFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {loadRenovateConfig} from "./renovate.ts";
+
+const fixturesDir = new URL("../fixtures/renovate/", import.meta.url).pathname;
+
+const created: Array<string> = [];
+
+function makeDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "updates-renovate-"));
+  created.push(d);
+  return d;
+}
+
+afterAll(() => {
+  for (const d of created) rmSync(d, {recursive: true, force: true});
+});
+
+test("no config returns empty", async () => {
+  expect(await loadRenovateConfig(makeDir())).toEqual({});
+});
+
+test("minimumReleaseAge → cooldown (days)", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({minimumReleaseAge: "3 days"}));
+  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 3});
+});
+
+test("minimumReleaseAge weeks", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({minimumReleaseAge: "1 week"}));
+  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 7});
+});
+
+test("minimumReleaseAge hours", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({minimumReleaseAge: "12 hours"}));
+  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 0.5});
+});
+
+test("ignoreDeps → exclude", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({ignoreDeps: ["foo", "bar"]}));
+  expect(await loadRenovateConfig(dir)).toEqual({exclude: ["foo", "bar"]});
+});
+
+test("packageRules disabled → exclude", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    packageRules: [{matchPackageNames: ["foo", "bar"], enabled: false}],
+  }));
+  expect(await loadRenovateConfig(dir)).toEqual({exclude: ["foo", "bar"]});
+});
+
+test("packageRules allowedVersions → pin", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    packageRules: [{matchPackageNames: ["react"], allowedVersions: "^18.0.0"}],
+  }));
+  expect(await loadRenovateConfig(dir)).toEqual({pin: {react: "^18.0.0"}});
+});
+
+test("packageRules with non-name matchers are skipped", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    packageRules: [
+      {matchPackageNames: ["foo"], matchUpdateTypes: ["major"], enabled: false},
+      {matchManagers: ["npm"], enabled: false},
+    ],
+  }));
+  expect(await loadRenovateConfig(dir)).toEqual({});
+});
+
+test("invalid allowedVersions range is ignored", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    packageRules: [{matchPackageNames: ["foo"], allowedVersions: "not-a-range"}],
+  }));
+  expect(await loadRenovateConfig(dir)).toEqual({});
+});
+
+test("renovate.json5 with comments and trailing commas", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json5"), `{
+    // pin react
+    "packageRules": [
+      {"matchPackageNames": ["react"], "allowedVersions": "^18.0.0",},
+    ],
+  }`);
+  expect(await loadRenovateConfig(dir)).toEqual({pin: {react: "^18.0.0"}});
+});
+
+test.each([".github", ".gitea", ".gitlab"])("forge dir config in %s", async (forge) => {
+  const dir = makeDir();
+  mkdirSync(join(dir, forge));
+  writeFileSync(join(dir, forge, "renovate.json"), JSON.stringify({minimumReleaseAge: "2 days"}));
+  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 2});
+});
+
+test("package.json renovate field", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "package.json"), JSON.stringify({
+    name: "x",
+    renovate: {minimumReleaseAge: "5 days", ignoreDeps: ["foo"]},
+  }));
+  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 5, exclude: ["foo"]});
+});
+
+test("renovate.json wins over forge config", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({minimumReleaseAge: "1 day"}));
+  mkdirSync(join(dir, ".github"));
+  writeFileSync(join(dir, ".github", "renovate.json"), JSON.stringify({minimumReleaseAge: "9 days"}));
+  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 1});
+});
+
+test("real-world config", async () => {
+  const dir = makeDir();
+  copyFileSync(join(fixturesDir, "real-world.json5"), join(dir, "renovate.json5"));
+  expect(await loadRenovateConfig(dir)).toEqual({
+    cooldown: 5,
+    pin: {
+      "@mcaptcha/vanilla-glue": "^0.1",
+      "cropperjs": "^1",
+      "tailwindcss": "^3",
+    },
+  });
+});
+
+test("malformed config throws", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), `{bad json`);
+  await expect(loadRenovateConfig(dir)).rejects.toThrow(/Unable to parse renovate config/);
+});

--- a/utils/renovate.test.ts
+++ b/utils/renovate.test.ts
@@ -92,7 +92,7 @@ test("renovate.json5 with comments and trailing commas", async () => {
   expect(await loadRenovateConfig(dir)).toEqual({pin: {react: "^18.0.0"}});
 });
 
-test.each([".github", ".gitea", ".gitlab"])("forge dir config in %s", async (forge) => {
+test.each([".github", ".gitea", ".forgejo", ".gitlab"])("forge dir config in %s", async (forge) => {
   const dir = makeDir();
   mkdirSync(join(dir, forge));
   writeFileSync(join(dir, forge, "renovate.json"), JSON.stringify({minimumReleaseAge: "2 days"}));

--- a/utils/renovate.test.ts
+++ b/utils/renovate.test.ts
@@ -121,6 +121,7 @@ test("real-world config", async () => {
   copyFileSync(join(fixturesDir, "real-world.json5"), join(dir, "renovate.json5"));
   expect(await loadRenovateConfig(dir)).toEqual({
     cooldown: 5,
+    exclude: [/^@types\//],
     pin: {
       "@mcaptcha/vanilla-glue": "^0.1",
       "cropperjs": "^1",

--- a/utils/renovate.ts
+++ b/utils/renovate.ts
@@ -85,6 +85,17 @@ async function readFirstExisting(rootDir: string): Promise<{path: string, text: 
   return undefined;
 }
 
+/** Renovate uses /pattern/ or /pattern/flags for regex matchers. */
+function toMatcher(name: string): string | RegExp {
+  const m = /^\/(.+)\/([a-z]*)$/.exec(name);
+  if (!m) return name;
+  try {
+    return new RegExp(m[1], m[2]);
+  } catch {
+    return name;
+  }
+}
+
 function normalize(raw: RenovateConfig): Partial<Config> {
   const out: Partial<Config> = {};
 
@@ -93,7 +104,7 @@ function normalize(raw: RenovateConfig): Partial<Config> {
     if (days !== undefined && days > 0) out.cooldown = days;
   }
 
-  const exclude: Array<string> = [];
+  const exclude: Array<string | RegExp> = [];
   const pin: Record<string, string> = {};
 
   if (Array.isArray(raw.ignoreDeps)) {
@@ -107,7 +118,7 @@ function normalize(raw: RenovateConfig): Partial<Config> {
       if (!rule || typeof rule !== "object" || !isSimpleRule(rule)) continue;
       const names = rule.matchPackageNames!.filter((n): n is string => typeof n === "string" && Boolean(n));
       if (rule.enabled === false) {
-        for (const name of names) exclude.push(name);
+        for (const name of names) exclude.push(toMatcher(name));
       }
       if (typeof rule.allowedVersions === "string" && validRange(rule.allowedVersions)) {
         for (const name of names) pin[name] = rule.allowedVersions;

--- a/utils/renovate.ts
+++ b/utils/renovate.ts
@@ -4,7 +4,7 @@ import {parseJsonish} from "./json5.ts";
 import {validRange} from "./semver.ts";
 import type {Config} from "../config.ts";
 
-const forgeDirs = [".github", ".gitea", ".gitlab"];
+const forgeDirs = [".github", ".gitea", ".forgejo", ".gitlab"];
 
 const configFileNames = [
   "renovate.json",

--- a/utils/renovate.ts
+++ b/utils/renovate.ts
@@ -1,0 +1,135 @@
+import {join} from "node:path";
+import {readFile} from "node:fs/promises";
+import {parseJsonish} from "./json5.ts";
+import {validRange} from "./semver.ts";
+import type {Config} from "../config.ts";
+
+const forgeDirs = [".github", ".gitea", ".gitlab"];
+
+const configFileNames = [
+  "renovate.json",
+  "renovate.json5",
+  ...forgeDirs.flatMap(dir => [`${dir}/renovate.json`, `${dir}/renovate.json5`]),
+  ".renovaterc",
+  ".renovaterc.json",
+  ".renovaterc.json5",
+];
+
+const durationUnits: Record<string, number> = {
+  y: 365, year: 365, years: 365,
+  mo: 30, month: 30, months: 30,
+  w: 7, week: 7, weeks: 7,
+  d: 1, day: 1, days: 1,
+  h: 1 / 24, hour: 1 / 24, hours: 1 / 24,
+  min: 1 / 1440, minute: 1 / 1440, minutes: 1 / 1440,
+  s: 1 / 86400, second: 1 / 86400, seconds: 1 / 86400,
+};
+
+/** Parse a renovate duration string ("3 days", "1 week", "12 hours") into days. */
+function parseRenovateDuration(str: string): number | undefined {
+  let total = 0;
+  let matched = false;
+  const re = /(\d+(?:\.\d+)?)\s*([a-z]+)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(str)) !== null) {
+    const mult = durationUnits[m[2].toLowerCase()];
+    if (mult === undefined) return undefined;
+    total += Number(m[1]) * mult;
+    matched = true;
+  }
+  return matched ? total : undefined;
+}
+
+type RenovateConfig = {
+  minimumReleaseAge?: string;
+  ignoreDeps?: Array<string>;
+  packageRules?: Array<RenovatePackageRule>;
+  [key: string]: unknown;
+};
+
+type RenovatePackageRule = {
+  matchPackageNames?: Array<string>;
+  enabled?: boolean;
+  allowedVersions?: string;
+  [key: string]: unknown;
+};
+
+/**
+ * A packageRule is "simple" if its only matcher is matchPackageNames. Rules
+ * with other matchers (matchUpdateTypes, matchManagers, matchFileNames, etc.)
+ * cannot be cleanly mapped to updates' config.
+ */
+function isSimpleRule(rule: RenovatePackageRule): boolean {
+  if (!Array.isArray(rule.matchPackageNames) || !rule.matchPackageNames.length) return false;
+  for (const key of Object.keys(rule)) {
+    if (key.startsWith("match") && key !== "matchPackageNames") return false;
+  }
+  return true;
+}
+
+async function readFirstExisting(rootDir: string): Promise<{path: string, text: string} | undefined> {
+  for (const name of configFileNames) {
+    const path = join(rootDir, ...name.split("/"));
+    try {
+      const text = await readFile(path, "utf8");
+      return {path, text};
+    } catch {}
+  }
+  try {
+    const text = await readFile(join(rootDir, "package.json"), "utf8");
+    const pkg = JSON.parse(text);
+    if (pkg && typeof pkg === "object" && pkg.renovate && typeof pkg.renovate === "object") {
+      return {path: "package.json", text: JSON.stringify(pkg.renovate)};
+    }
+  } catch {}
+  return undefined;
+}
+
+function normalize(raw: RenovateConfig): Partial<Config> {
+  const out: Partial<Config> = {};
+
+  if (typeof raw.minimumReleaseAge === "string") {
+    const days = parseRenovateDuration(raw.minimumReleaseAge);
+    if (days !== undefined && days > 0) out.cooldown = days;
+  }
+
+  const exclude: Array<string> = [];
+  const pin: Record<string, string> = {};
+
+  if (Array.isArray(raw.ignoreDeps)) {
+    for (const dep of raw.ignoreDeps) {
+      if (typeof dep === "string" && dep) exclude.push(dep);
+    }
+  }
+
+  if (Array.isArray(raw.packageRules)) {
+    for (const rule of raw.packageRules) {
+      if (!rule || typeof rule !== "object" || !isSimpleRule(rule)) continue;
+      const names = rule.matchPackageNames!.filter((n): n is string => typeof n === "string" && Boolean(n));
+      if (rule.enabled === false) {
+        for (const name of names) exclude.push(name);
+      }
+      if (typeof rule.allowedVersions === "string" && validRange(rule.allowedVersions)) {
+        for (const name of names) pin[name] = rule.allowedVersions;
+      }
+    }
+  }
+
+  if (exclude.length) out.exclude = exclude;
+  if (Object.keys(pin).length) out.pin = pin;
+
+  return out;
+}
+
+export async function loadRenovateConfig(rootDir: string): Promise<Partial<Config>> {
+  const found = await readFirstExisting(rootDir);
+  if (!found) return {};
+  let raw: unknown;
+  try {
+    raw = parseJsonish(found.text);
+  } catch (err: any) {
+    throw new Error(`Unable to parse renovate config ${found.path}: ${err.message}`);
+  }
+  if (!raw || typeof raw !== "object") return {};
+  return normalize(raw as RenovateConfig);
+}


### PR DESCRIPTION
Discovers a renovate config in the same order renovate itself does (`renovate.json`, `renovate.json5`, `.github`/`.gitea`/`.forgejo`/`.gitlab`/`renovate.{json,json5}`, `.renovaterc{,.json,.json5}`, `package.json` `renovate` field) and extracts the options that map cleanly to updates' config:

- `minimumReleaseAge` → `cooldown`
- `ignoreDeps` → `exclude`
- `packageRules` with only `matchPackageNames` + `enabled: false` → `exclude`
- `packageRules` with only `matchPackageNames` + `allowedVersions` → `pin`

Precedence: renovate < `updates.config.*` < CLI. Includes a small JSON5/JSONC-tolerant parser (line/block comments, trailing commas) so no JSON5 dependency is needed. `packageRules` with non-name matchers (`matchManagers`, `matchUpdateTypes`, etc.) are skipped, and `rangeStrategy: "pin"` is skipped because its semantics don't map to updates' `pin`.

Closes #131
Closes #132

---
This PR was written with the help of Claude Opus 4.7