### PR TITLE
Make renovate cooldown inheritance opt-in

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -57,6 +57,13 @@ export type Config = {
   minor?: boolean | Array<string | RegExp>;
   /** Allow version downgrades when using latest version */
   allowDowngrade?: boolean | Array<string | RegExp>;
+  /** Opt-in to inheriting select fields from other tools' configs */
+  inherit?: {
+    renovate?: {
+      /** Inherit minimumReleaseAge as cooldown. Off by default. */
+      cooldown?: boolean;
+    };
+  };
 };
 
 export type Arg = string | boolean | Array<string | boolean> | undefined;
@@ -179,7 +186,6 @@ export async function loadConfig(rootDir: string): Promise<Config> {
   for (const ext of ["js", "ts", "mjs", "mts"]) {
     filenames.push(`updates.config.${ext}`);
   }
-  const renovateConfig = await loadRenovateConfig(rootDir);
   let config: Config = {};
 
   try {
@@ -208,5 +214,6 @@ export async function loadConfig(rootDir: string): Promise<Config> {
     }
   }
 
+  const renovateConfig = await loadRenovateConfig(rootDir, config.inherit?.renovate);
   return {...renovateConfig, ...config};
 }

--- a/utils/renovate.test.ts
+++ b/utils/renovate.test.ts
@@ -23,22 +23,28 @@ test("no config returns empty", async () => {
   expect(await loadRenovateConfig(makeDir())).toEqual({});
 });
 
+test("minimumReleaseAge skipped without opt-in", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({minimumReleaseAge: "3 days"}));
+  expect(await loadRenovateConfig(dir)).toEqual({});
+});
+
 test("minimumReleaseAge → cooldown (days)", async () => {
   const dir = makeDir();
   writeFileSync(join(dir, "renovate.json"), JSON.stringify({minimumReleaseAge: "3 days"}));
-  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 3});
+  expect(await loadRenovateConfig(dir, {cooldown: true})).toEqual({cooldown: 3});
 });
 
 test("minimumReleaseAge weeks", async () => {
   const dir = makeDir();
   writeFileSync(join(dir, "renovate.json"), JSON.stringify({minimumReleaseAge: "1 week"}));
-  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 7});
+  expect(await loadRenovateConfig(dir, {cooldown: true})).toEqual({cooldown: 7});
 });
 
 test("minimumReleaseAge hours", async () => {
   const dir = makeDir();
   writeFileSync(join(dir, "renovate.json"), JSON.stringify({minimumReleaseAge: "12 hours"}));
-  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 0.5});
+  expect(await loadRenovateConfig(dir, {cooldown: true})).toEqual({cooldown: 0.5});
 });
 
 test("ignoreDeps → exclude", async () => {
@@ -97,7 +103,7 @@ test.each([".github", ".gitea", ".forgejo", ".gitlab"])("forge dir config in %s"
   const dir = makeDir();
   mkdirSync(join(dir, forge));
   writeFileSync(join(dir, forge, "renovate.json"), JSON.stringify({minimumReleaseAge: "2 days"}));
-  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 2});
+  expect(await loadRenovateConfig(dir, {cooldown: true})).toEqual({cooldown: 2});
 });
 
 test("package.json renovate field", async () => {
@@ -106,7 +112,7 @@ test("package.json renovate field", async () => {
     name: "x",
     renovate: {minimumReleaseAge: "5 days", ignoreDeps: ["foo"]},
   }));
-  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 5, exclude: ["foo"]});
+  expect(await loadRenovateConfig(dir, {cooldown: true})).toEqual({cooldown: 5, exclude: ["foo"]});
 });
 
 test("renovate.json wins over forge config", async () => {
@@ -114,13 +120,13 @@ test("renovate.json wins over forge config", async () => {
   writeFileSync(join(dir, "renovate.json"), JSON.stringify({minimumReleaseAge: "1 day"}));
   mkdirSync(join(dir, ".github"));
   writeFileSync(join(dir, ".github", "renovate.json"), JSON.stringify({minimumReleaseAge: "9 days"}));
-  expect(await loadRenovateConfig(dir)).toEqual({cooldown: 1});
+  expect(await loadRenovateConfig(dir, {cooldown: true})).toEqual({cooldown: 1});
 });
 
 test("real-world config", async () => {
   const dir = makeDir();
   copyFileSync(join(fixturesDir, "real-world.json5"), join(dir, "renovate.json5"));
-  expect(await loadRenovateConfig(dir)).toEqual({
+  expect(await loadRenovateConfig(dir, {cooldown: true})).toEqual({
     cooldown: 5,
     exclude: [/^@types\//],
     pin: {

--- a/utils/renovate.ts
+++ b/utils/renovate.ts
@@ -96,10 +96,15 @@ function toMatcher(name: string): string | RegExp {
   }
 }
 
-function normalize(raw: RenovateConfig): Partial<Config> {
+export type RenovateImportOptions = {
+  /** Import minimumReleaseAge as cooldown. Off by default. */
+  cooldown?: boolean;
+};
+
+function normalize(raw: RenovateConfig, opts: RenovateImportOptions): Partial<Config> {
   const out: Partial<Config> = {};
 
-  if (typeof raw.minimumReleaseAge === "string") {
+  if (opts.cooldown && typeof raw.minimumReleaseAge === "string") {
     const days = parseRenovateDuration(raw.minimumReleaseAge);
     if (days !== undefined && days > 0) out.cooldown = days;
   }
@@ -132,7 +137,7 @@ function normalize(raw: RenovateConfig): Partial<Config> {
   return out;
 }
 
-export async function loadRenovateConfig(rootDir: string): Promise<Partial<Config>> {
+export async function loadRenovateConfig(rootDir: string, opts: RenovateImportOptions = {}): Promise<Partial<Config>> {
   const found = await readFirstExisting(rootDir);
   if (!found) return {};
   let raw: unknown;
@@ -142,5 +147,5 @@ export async function loadRenovateConfig(rootDir: string): Promise<Partial<Confi
     throw new Error(`Unable to parse renovate config ${found.path}: ${err.message}`);
   }
   if (!raw || typeof raw !== "object") return {};
-  return normalize(raw as RenovateConfig);
+  return normalize(raw as RenovateConfig, opts);
 }


### PR DESCRIPTION
`minimumReleaseAge` from a renovate config is no longer auto-imported as `cooldown`. Opt in via:

```js
export default {
  inherit: { renovate: { cooldown: true } },
};
```

The `inherit` shape is generic so other tools (e.g. dependabot) can be added later. Other renovate fields (`ignoreDeps`, `packageRules` → `exclude`/`pin`) are still parsed by default.

---
This PR was written with the help of Claude Opus 4.7