### PR TITLE
Honor pinnedRange in Go mode

### DIFF
--- a/modes/shared.test.ts
+++ b/modes/shared.test.ts
@@ -695,6 +695,46 @@ test("findNewVersion go mode same-major fallback", () => {
   expect(result).toBe("1.5.0");
 });
 
+test("findNewVersion go mode honors pinnedRange on cross-major target", () => {
+  const data = {name: "github.com/foo/bar", old: "1.0.0", new: "3.0.0", Time: "2025-03-01"};
+  const result = findNewVersion(data, {
+    mode: "go", range: "1.0.0",
+    useGreatest: false, useRel: false, usePre: false,
+    semvers: new Set(["major"]), pinnedRange: "<2.0.0",
+  }, defaultOpts);
+  expect(result).toBe(null);
+});
+
+test("findNewVersion go mode honors pinnedRange on same-major fallback", () => {
+  const data = {
+    name: "github.com/foo/bar",
+    old: "1.0.0", new: "3.0.0",
+    sameMajorNew: "1.7.0", sameMajorTime: "2025-02-01",
+    Time: "2025-03-01",
+  };
+  const result = findNewVersion(data, {
+    mode: "go", range: "1.0.0",
+    useGreatest: false, useRel: false, usePre: false,
+    semvers: new Set(["patch", "minor"]), pinnedRange: "<1.5.0",
+  }, defaultOpts);
+  expect(result).toBe(null);
+});
+
+test("findNewVersion go mode allows pinnedRange-matching version", () => {
+  const data = {
+    name: "github.com/foo/bar",
+    old: "1.0.0", new: "3.0.0",
+    sameMajorNew: "1.4.0", sameMajorTime: "2025-02-01",
+    Time: "2025-03-01",
+  };
+  const result = findNewVersion(data, {
+    mode: "go", range: "1.0.0",
+    useGreatest: false, useRel: false, usePre: false,
+    semvers: new Set(["patch", "minor"]), pinnedRange: "<1.5.0",
+  }, defaultOpts);
+  expect(result).toBe("1.4.0");
+});
+
 test("resolvePackageJsonUrl shorthand foo:u/r", () => {
   expect(resolvePackageJsonUrl("g:u/r")).toBe("https://g.com/u/r");
 });

--- a/modes/shared.ts
+++ b/modes/shared.ts
@@ -282,7 +282,8 @@ export function findNewVersion(data: any, {mode, range, useGreatest, useRel, use
     if (crossVersion && !isGoPseudoVersion(data.new) && !skipPrerelease(data.new)) {
       const d = diff(oldVersion, crossVersion);
       if (d && semvers.has(d) && isAllowedVersionTransition(originalOldVersion, data.new, transitionOpts) &&
-          passesCooldown(data.Time, cooldownDays, now)) {
+          passesCooldown(data.Time, cooldownDays, now) &&
+          (!pinnedRange || satisfies(crossVersion, pinnedRange))) {
         return data.new;
       }
     }
@@ -292,7 +293,8 @@ export function findNewVersion(data: any, {mode, range, useGreatest, useRel, use
     if (sameVersion && !isGoPseudoVersion(data.sameMajorNew) && !skipPrerelease(data.sameMajorNew)) {
       const d = diff(oldVersion, sameVersion);
       if (d && semvers.has(d) && isAllowedVersionTransition(originalOldVersion, data.sameMajorNew, transitionOpts) &&
-          passesCooldown(data.sameMajorTime, cooldownDays, now)) {
+          passesCooldown(data.sameMajorTime, cooldownDays, now) &&
+          (!pinnedRange || satisfies(sameVersion, pinnedRange))) {
         data.Time = data.sameMajorTime;
         delete data.newPath;
         return data.sameMajorNew;
@@ -305,7 +307,8 @@ export function findNewVersion(data: any, {mode, range, useGreatest, useRel, use
       const v = coerceToVersion(data.olderEligible.version);
       if (v) {
         const d = diff(oldVersion, v);
-        if (d && semvers.has(d) && isAllowedVersionTransition(originalOldVersion, data.olderEligible.version, transitionOpts)) {
+        if (d && semvers.has(d) && isAllowedVersionTransition(originalOldVersion, data.olderEligible.version, transitionOpts) &&
+            (!pinnedRange || satisfies(v, pinnedRange))) {
           data.Time = data.olderEligible.time;
           delete data.newPath;
           return data.olderEligible.version;


### PR DESCRIPTION
The Go branch of `findNewVersion` (`modes/shared.ts:271-315`) picked `data.new` / `data.sameMajorNew` / `data.olderEligible` without checking `pinnedRange`. Renovate-config-derived `allowedVersions` rules (and explicit `pin` config entries) were silently ignored for gomod deps — the npm/cargo/pypi paths honor the pin via `findVersion`, but Go has its own selection logic that bypassed it.

Filter each Go candidate against `pinnedRange` using `satisfies`, matching how the other ecosystems already work. Returns null when no eligible candidate is in range, so the dep correctly drops out of the update set.

**Tests added** (`modes/shared.test.ts`):
- pinnedRange blocks cross-major target
- pinnedRange blocks same-major fallback
- pinnedRange-matching version still returns

All 482 tests pass; lint clean.

**Concrete trigger:** go-gitea/gitea has five `replace` directives pinning Azure SDK / mssqldb / urfave/cli / yaml/v4 versions for compatibility reasons. Their renovate config now declares matching `allowedVersions` rules, but `updates` was still surfacing those bumps because the Go path didn't apply the pin.

---
This PR was written with the help of Claude Opus 4.7