### PR TITLE
Drop `process.exit()` to let Node shut down naturally

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,11 +11,6 @@ jobs:
       matrix:
         js: [[node, 22], [node, 24], [node, 26], [bun, latest]]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude: # https://github.com/nodejs/node/issues/56645
-          - js: [node, 24]
-            os: windows-latest
-          - js: [node, 26]
-            os: windows-latest
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v6

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import {argv, cwd, stdout, stderr, exit, platform, versions} from "node:process";
+import {argv, cwd, stdout} from "node:process";
 import {stripVTControlCharacters, styleText, parseArgs} from "node:util";
 import {dirname, isAbsolute, resolve} from "node:path";
 import {statSync} from "node:fs";
@@ -66,7 +66,7 @@ function resolveColor(fileConfig: UpdatesOptions): boolean {
   return Boolean(stdout.isTTY);
 }
 
-async function end(err?: Error | void, exitCode?: number): Promise<void> {
+function end(err?: Error | void, exitCode?: number): void {
   if (err) {
     const error = err.message ?? String(err);
     if (args.json) {
@@ -76,18 +76,10 @@ async function end(err?: Error | void, exitCode?: number): Promise<void> {
     }
   }
 
-  if (platform === "win32" && Number(versions?.node?.split(".")[0]) >= 23) {
-    await new Promise(resolve => setTimeout(resolve, 50));
-  }
-
-  exit(exitCode ?? (err ? 1 : 0));
+  process.exitCode = exitCode ?? (err ? 1 : 0);
 }
 
 async function main(): Promise<void> {
-  for (const stream of [stdout, stderr]) {
-    (stream as any)?._handle?.setBlocking?.(true);
-  }
-
   const maxSockets = 25;
 
   if (args.help) {
@@ -136,12 +128,14 @@ async function main(): Promise<void> {
     $ updates -f Dockerfile
     $ updates -f docker-compose.yml
 `);
-    await end();
+    end();
+    return;
   }
 
   if (args.version) {
     console.info(packageVersion);
-    await end();
+    end();
+    return;
   }
 
   const fileSet = parseMixedArg(args.file);
@@ -219,11 +213,11 @@ async function main(): Promise<void> {
   }
 
   if (config.errorOnOutdated) {
-    await end(undefined, hasResults ? 2 : 0);
+    end(undefined, hasResults ? 2 : 0);
   } else if (config.errorOnUnchanged) {
-    await end(undefined, hasResults ? 0 : 2);
+    end(undefined, hasResults ? 0 : 2);
   } else {
-    await end();
+    end();
   }
 }
 
@@ -263,5 +257,5 @@ function formatOutput(output: Output): string {
 try {
   await main();
 } catch (err) {
-  await end(err as Error);
+  end(err as Error);
 }

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,9 @@ import {prewarmOrigins} from "./utils/prewarm.ts";
 import type {Arg} from "./config.ts";
 import type {Output, UpdatesOptions} from "./api.ts";
 
-for (const url of prewarmOrigins(cwd(), argv.slice(2))) fetch(url, {method: "HEAD"}).catch(() => {});
+const prewarmAbort = new AbortController();
+const prewarms = prewarmOrigins(cwd(), argv.slice(2))
+  .map(url => fetch(url, {method: "HEAD", signal: prewarmAbort.signal}).catch(() => {}));
 
 const result = parseArgs({
   strict: false,
@@ -66,7 +68,7 @@ function resolveColor(fileConfig: UpdatesOptions): boolean {
   return Boolean(stdout.isTTY);
 }
 
-function end(err?: Error | void, exitCode?: number): void {
+async function end(err?: Error | void, exitCode?: number): Promise<void> {
   if (err) {
     const error = err.message ?? String(err);
     if (args.json) {
@@ -76,6 +78,8 @@ function end(err?: Error | void, exitCode?: number): void {
     }
   }
 
+  prewarmAbort.abort();
+  await Promise.all(prewarms);
   process.exitCode = exitCode ?? (err ? 1 : 0);
 }
 
@@ -128,13 +132,13 @@ async function main(): Promise<void> {
     $ updates -f Dockerfile
     $ updates -f docker-compose.yml
 `);
-    end();
+    await end();
     return;
   }
 
   if (args.version) {
     console.info(packageVersion);
-    end();
+    await end();
     return;
   }
 
@@ -213,11 +217,11 @@ async function main(): Promise<void> {
   }
 
   if (config.errorOnOutdated) {
-    end(undefined, hasResults ? 2 : 0);
+    await end(undefined, hasResults ? 2 : 0);
   } else if (config.errorOnUnchanged) {
-    end(undefined, hasResults ? 0 : 2);
+    await end(undefined, hasResults ? 0 : 2);
   } else {
-    end();
+    await end();
   }
 }
 
@@ -257,5 +261,5 @@ function formatOutput(output: Output): string {
 try {
   await main();
 } catch (err) {
-  end(err as Error);
+  await end(err as Error);
 }


### PR DESCRIPTION
The 50ms Windows workaround for nodejs/node#56645 was insufficient on Node 26 — the libuv assertion fires from `uv_async_send` after `uv_close`, which the explicit `exit()` precipitates. Setting `process.exitCode` and letting the event loop drain avoids the racy shutdown path entirely.

Removes the `setBlocking()` workaround on stdout/stderr too — it was only needed because `exit()` doesn't flush async writes; natural shutdown does.

Re-enables Node 24 and 26 on Windows in CI.

---
This PR was written with the help of Claude Opus 4.7