### PR TITLE
Respect package managers' native minimum release age

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ export default {
 
 Values in `updates.config` override anything inherited.
 
+### Native package manager minimum release age
+
+For npm packages, `updates` automatically honors the minimum-release-age supply-chain settings that npm, pnpm and bun expose, so it won't propose a version those package managers would refuse to install. The nearest config above each manifest is read:
+
+|Package manager|File|Setting (and unit)|Exclude list|
+|---|---|---|---|
+|npm|`.npmrc`|`min-release-age` (days)|`min-release-age-exclude`|
+|pnpm|`pnpm-workspace.yaml` or `.npmrc`|`minimumReleaseAge` / `minimum-release-age` (minutes)|`minimumReleaseAgeExclude` / `minimum-release-age-exclude`|
+|bun|`bunfig.toml` `[install]`|`minimumReleaseAge` (seconds)|`minimumReleaseAgeExcludes`|
+
+When several are present, the most conservative age and the union of exclude lists apply. An explicit `cooldown` in `updates.config`, `--cooldown`, or an `overrides` entry always takes precedence over the native value; the native value is only used as a fallback when `updates` has no cooldown of its own.
+
 ## API
 
 `updates` can be used as a library:

--- a/README.md
+++ b/README.md
@@ -128,13 +128,14 @@ Values in `updates.config` override anything inherited.
 
 ### Native package manager minimum release age
 
-For npm packages, `updates` automatically honors the minimum-release-age supply-chain settings that npm, pnpm and bun expose, so it won't propose a version those package managers would refuse to install. The nearest config above each manifest is read:
+For npm packages, `updates` automatically honors the minimum-release-age supply-chain settings that npm, pnpm, bun and yarn expose, so it won't propose a version those package managers would refuse to install. The nearest config above each manifest is read:
 
 |Package manager|File|Setting (and unit)|Exclude list|
 |---|---|---|---|
 |npm|`.npmrc`|`min-release-age` (days)|`min-release-age-exclude`|
 |pnpm|`pnpm-workspace.yaml` or `.npmrc`|`minimumReleaseAge` / `minimum-release-age` (minutes)|`minimumReleaseAgeExclude` / `minimum-release-age-exclude`|
 |bun|`bunfig.toml` `[install]`|`minimumReleaseAge` (seconds)|`minimumReleaseAgeExcludes`|
+|yarn|`.yarnrc.yml`|`npmMinimalAgeGate` (minutes, or a duration like `7d`)|`npmPreapprovedPackages`|
 
 When several are present, the most conservative age and the union of exclude lists apply. An explicit `cooldown` in `updates.config`, `--cooldown`, or an `overrides` entry always takes precedence over the native value; the native value is only used as a fallback when `updates` has no cooldown of its own.
 

--- a/api.ts
+++ b/api.ts
@@ -16,6 +16,7 @@ import {
 } from "./modes/shared.ts";
 import {loadConfig, configMixedToRegexes, patternsToRegexSet} from "./config.ts";
 import type {Config, Override} from "./config.ts";
+import {npmEcosystemCooldown} from "./utils/pmCooldown.ts";
 import {
   fetchNpmInfo, fetchNpmVersionInfo, fetchJsrInfo, isJsr, isLocalDep, parseJsrDependency,
   getNpmrc, updatePackageJson, updateVersionRange, normalizeRange, checkUrlDep,
@@ -374,12 +375,41 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
   // never overwrites each other's content/config and never merges their deps.
   // Each gets a unique memberPath (the first stays "." to preserve the original
   // single-manifest output shape), mirroring the workspace `|memberPath` scheme.
-  type PlainFile = {absPath: string, content: string, memberPath: string, projectDir: string, modeConfig: Config, pin: Record<string, string>, modeCooldownDays: number};
+  type Native = {nativeCooldownDays: number, nativeExclude: Set<RegExp>};
+  type PlainFile = {absPath: string, content: string, memberPath: string, projectDir: string, modeConfig: Config, pin: Record<string, string>, modeCooldownDays: number | undefined} & Native;
   const plainFiles: Record<string, Array<PlainFile>> = {};
   const now = Date.now();
-  const cooldownDaysFor = (local: Config["cooldown"]) => {
+  // Returns the `updates`-configured cooldown in days, or undefined when neither
+  // a global nor a local cooldown is set. An explicit 0 is kept distinct from
+  // undefined so that `cooldown: 0` / `--cooldown 0` disables the native fallback.
+  const cooldownDaysFor = (local: Config["cooldown"]): number | undefined => {
     const raw = config.cooldown ?? local;
-    return raw ? parseDuration(String(raw)) : 0;
+    return raw === undefined || raw === null ? undefined : parseDuration(String(raw));
+  };
+  // Native package-manager minimum-release-age settings (npm/pnpm/bun), resolved
+  // per project dir. Only the npm mode has such settings. Exclude patterns may be
+  // globs (e.g. `@myorg/*`), so they are compiled to the same matcher used
+  // elsewhere. Memoized per run so repeated lookups don't re-walk the filesystem.
+  const emptyExclude = new Set<RegExp>();
+  const nativeCache = new Map<string, Native>();
+  const nativeFor = (mode: string, projectDir: string): Native => {
+    if (mode !== "npm") return {nativeCooldownDays: 0, nativeExclude: emptyExclude};
+    let entry = nativeCache.get(projectDir);
+    if (!entry) {
+      const {days, exclude} = npmEcosystemCooldown(projectDir);
+      entry = {nativeCooldownDays: days, nativeExclude: exclude.size ? patternsToRegexSet(Array.from(exclude)) : emptyExclude};
+      nativeCache.set(projectDir, entry);
+    }
+    return entry;
+  };
+  // Effective cooldown for a dependency. An explicit `updates` cooldown (override
+  // or mode/global config, including an explicit 0) wins; otherwise fall back to
+  // the native PM setting, which a native exclude list can waive per package.
+  const resolveCooldownDays = (name: string, modeCooldownDays: number | undefined, cooldownOverride: number | undefined, nativeCooldownDays: number, nativeExclude: Set<RegExp>) => {
+    if (cooldownOverride !== undefined) return cooldownOverride;
+    if (modeCooldownDays !== undefined) return modeCooldownDays;
+    if (matchesAny(name, nativeExclude)) return 0;
+    return nativeCooldownDays;
   };
   const cwdStr = cwd();
   const toRelPath = (absPath: string) => absPath.replace(`${cwdStr}/`, "").replace(`${cwdStr}\\`, "");
@@ -475,7 +505,8 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
     const cfg = await loadConfig(fileDir);
     const inc = cfg.include?.length ? patternsToRegexSet([...(config.include ?? []), ...cfg.include]) : include;
     const exc = cfg.exclude?.length ? patternsToRegexSet([...(config.exclude ?? []), ...cfg.exclude]) : exclude;
-    return {include: inc, exclude: exc, pin: cfg.pin ?? {}, cooldownDays: cooldownDaysFor(cfg.cooldown)};
+    // docker/actions/make have no native fallback, so collapse undefined to 0.
+    return {include: inc, exclude: exc, pin: cfg.pin ?? {}, cooldownDays: cooldownDaysFor(cfg.cooldown) ?? 0};
   }
 
   for (const file of files) {
@@ -665,7 +696,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
         const modeFiles = plainFiles[mode] ??= [];
         const isFirstOfMode = !modeFiles.length;
         const memberPath = isFirstOfMode ? "." : toRelPath(file);
-        modeFiles.push({absPath: resolve(file), content: cargoContent, memberPath, projectDir: workspaceDir, modeConfig, pin, modeCooldownDays: cooldownDaysFor(modeConfig.cooldown)});
+        modeFiles.push({absPath: resolve(file), content: cargoContent, memberPath, projectDir: workspaceDir, modeConfig, pin, modeCooldownDays: cooldownDaysFor(modeConfig.cooldown), ...nativeFor(mode, workspaceDir)});
         if (isFirstOfMode) modeConfigs[mode] = {modeConfig, projectDir: workspaceDir, pin};
         collectCargoDeps(cargoParsed, memberPath === "." ? "" : `|${memberPath}`);
       }
@@ -757,7 +788,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
     const memberPath = isFirstOfMode ? "." : toRelPath(file);
     const typePrefix = memberPath === "." ? "" : `|${memberPath}`;
     const content = fileContents.get(file)!;
-    modeFiles.push({absPath: resolve(file), content, memberPath, projectDir, modeConfig, pin, modeCooldownDays: cooldownDaysFor(modeConfig.cooldown)});
+    modeFiles.push({absPath: resolve(file), content, memberPath, projectDir, modeConfig, pin, modeCooldownDays: cooldownDaysFor(modeConfig.cooldown), ...nativeFor(mode, projectDir)});
 
     let pkg: Record<string, any> = {};
     try {
@@ -837,6 +868,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
     if (!hasDeps && !hasUrlDeps) continue;
     const {modeConfig: defaultModeConfig, projectDir: defaultProjectDir, pin: defaultPin} = modeConfigs[mode];
     const defaultCooldownDays = cooldownDaysFor(defaultModeConfig.cooldown);
+    const defaultNative = nativeFor(mode, defaultProjectDir);
     fetchTasks.push((async () => {
       // Non-workspace manifests with a disambiguating `|memberPath` type suffix
       // each carry their own config/projectDir/pin/cooldown; the empty-suffix
@@ -845,7 +877,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
       for (const entry of plainFiles[mode] ?? []) {
         if (entry.memberPath !== ".") ctxBySuffix.set(`|${entry.memberPath}`, entry);
       }
-      const defaultCtx = {modeConfig: defaultModeConfig, projectDir: defaultProjectDir, pin: defaultPin, modeCooldownDays: defaultCooldownDays};
+      const defaultCtx = {modeConfig: defaultModeConfig, projectDir: defaultProjectDir, pin: defaultPin, modeCooldownDays: defaultCooldownDays, ...defaultNative};
       const ctxForType = (type: string) => {
         const suffix = type.slice(baseType(type).length);
         return (suffix && ctxBySuffix.get(suffix)) || defaultCtx;
@@ -857,10 +889,10 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
       const dropIfTooNew = (modeDeps: Deps) => {
         for (const [k, {date}] of Object.entries(modeDeps)) {
           if (!date) continue;
-          const {modeCooldownDays} = ctxForType(k.split(fieldSep)[0]);
-          if (!modeCooldownDays && !overridesHaveCooldown) continue;
+          const {modeCooldownDays, nativeCooldownDays, nativeExclude} = ctxForType(k.split(fieldSep)[0]);
+          if (!modeCooldownDays && !nativeCooldownDays && !overridesHaveCooldown) continue;
           const [, name] = k.split(fieldSep);
-          const cd = getVersionOpts(name).cooldownOverride ?? modeCooldownDays;
+          const cd = resolveCooldownDays(name, modeCooldownDays, getVersionOpts(name).cooldownOverride, nativeCooldownDays, nativeExclude);
           if (cd && !passesCooldown(date, cd, now)) delete modeDeps[k];
         }
       };
@@ -868,7 +900,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
       await pMap(Object.keys(deps[mode]), async (key) => {
         const [type, name] = key.split(fieldSep);
         const baseT = baseType(type);
-        const {modeConfig, projectDir, pin, modeCooldownDays} = ctxForType(type);
+        const {modeConfig, projectDir, pin, modeCooldownDays, nativeCooldownDays, nativeExclude} = ctxForType(type);
         const dep = deps[mode][key];
         let info: PackageInfo | null = null;
         if (mode === "npm") {
@@ -901,7 +933,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
         const oldRange = dep.old;
         const oldOrig = dep.oldOrig;
         const pinnedRange = pin[name];
-        const depCooldownDays = cooldownOverride ?? modeCooldownDays;
+        const depCooldownDays = resolveCooldownDays(name, modeCooldownDays, cooldownOverride, nativeCooldownDays, nativeExclude);
         const newVersion = findNewVersion(data, {
           usePre, useRel, useGreatest, semvers, range: oldRange, mode, pinnedRange,
           cooldownDays: depCooldownDays || undefined, now: depCooldownDays ? now : undefined,

--- a/config.ts
+++ b/config.ts
@@ -17,7 +17,7 @@ export type Config = {
   /**
    * Minimum dependency age, e.g. 7 (days), "1w", "2d", "6h". When unset, npm
    * packages fall back to the native minimum-release-age settings found in
-   * .npmrc / pnpm-workspace.yaml / bunfig.toml.
+   * .npmrc / pnpm-workspace.yaml / bunfig.toml / .yarnrc.yml.
    */
   cooldown?: number | string;
   /** Pin dependencies to semver ranges */

--- a/config.ts
+++ b/config.ts
@@ -14,7 +14,11 @@ export type Config = {
   types?: Array<string>;
   /** URL to npm registry */
   registry?: string;
-  /** Minimum dependency age, e.g. 7 (days), "1w", "2d", "6h" */
+  /**
+   * Minimum dependency age, e.g. 7 (days), "1w", "2d", "6h". When unset, npm
+   * packages fall back to the native minimum-release-age settings found in
+   * .npmrc / pnpm-workspace.yaml / bunfig.toml.
+   */
   cooldown?: number | string;
   /** Pin dependencies to semver ranges */
   pin?: Record<string, string>;

--- a/index.test.ts
+++ b/index.test.ts
@@ -2369,6 +2369,26 @@ test("api native quoted minimumReleaseAge holds back too-new version", async ({e
   }
 });
 
+test("api native .yarnrc.yml npmMinimalAgeGate holds back too-new version", async ({expect = globalExpect}: any = {}) => {
+  const dir = await nativeCooldownDir("updates-native-yarn-", ".yarnrc.yml", "npmMinimalAgeGate: 1440000000\n");
+  try {
+    const output = await updates(apiOpts({files: [join(dir, "package.json")]}));
+    expect(output.message).toBe("All dependencies are up to date.");
+  } finally {
+    await rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100}).catch(() => {});
+  }
+});
+
+test("api native yarn npmPreapprovedPackages bypasses age gate", async ({expect = globalExpect}: any = {}) => {
+  const dir = await nativeCooldownDir("updates-native-yarn-ok-", ".yarnrc.yml", "npmMinimalAgeGate: 1440000000\nnpmPreapprovedPackages:\n  - noty\n");
+  try {
+    const output = await updates(apiOpts({files: [join(dir, "package.json")]}));
+    expect(output.results.npm.dependencies.noty.new).toBe("3.1.4");
+  } finally {
+    await rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100}).catch(() => {});
+  }
+});
+
 test("api modes filter", async ({expect = globalExpect}: any = {}) => {
   const output = await updates(apiOpts({include: ["noty"], modes: ["pypi"]}));
   expect(output.message).toBe("No dependencies found, nothing to do.");

--- a/index.test.ts
+++ b/index.test.ts
@@ -2282,6 +2282,93 @@ test("api overrides last match wins", async ({expect = globalExpect}: any = {}) 
   expect(output.results.npm.dependencies.noty.new).toBe("3.1.4");
 });
 
+async function nativeCooldownDir(prefix: string, configFile: string, configContent: string, deps: Record<string, string> = {noty: "3.1.0"}) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  writeFileSync(join(dir, configFile), configContent);
+  await writeFile(join(dir, "package.json"), `${JSON.stringify({dependencies: deps}, null, 2)}\n`);
+  return dir;
+}
+
+test("api native .npmrc min-release-age holds back too-new version", async ({expect = globalExpect}: any = {}) => {
+  const dir = await nativeCooldownDir("updates-native-npmrc-", ".npmrc", "min-release-age=999999\n");
+  try {
+    const output = await updates(apiOpts({files: [join(dir, "package.json")]}));
+    expect(output.message).toBe("All dependencies are up to date.");
+  } finally {
+    await rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100}).catch(() => {});
+  }
+});
+
+test("api native pnpm-workspace.yaml minimumReleaseAge holds back too-new version", async ({expect = globalExpect}: any = {}) => {
+  const dir = await nativeCooldownDir("updates-native-pnpm-", "pnpm-workspace.yaml", "minimumReleaseAge: 1440000000\n");
+  try {
+    const output = await updates(apiOpts({files: [join(dir, "package.json")]}));
+    expect(output.message).toBe("All dependencies are up to date.");
+  } finally {
+    await rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100}).catch(() => {});
+  }
+});
+
+test("api native bunfig.toml minimumReleaseAge holds back too-new version", async ({expect = globalExpect}: any = {}) => {
+  const dir = await nativeCooldownDir("updates-native-bun-", "bunfig.toml", "[install]\nminimumReleaseAge = 99999999999\n");
+  try {
+    const output = await updates(apiOpts({files: [join(dir, "package.json")]}));
+    expect(output.message).toBe("All dependencies are up to date.");
+  } finally {
+    await rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100}).catch(() => {});
+  }
+});
+
+test("api explicit cooldown overrides native min-release-age", async ({expect = globalExpect}: any = {}) => {
+  const dir = await nativeCooldownDir("updates-native-override-", ".npmrc", "min-release-age=999999\n");
+  try {
+    const output = await updates(apiOpts({files: [join(dir, "package.json")], cooldown: "1d"}));
+    expect(output.results.npm.dependencies.noty.new).toBe("3.1.4");
+  } finally {
+    await rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100}).catch(() => {});
+  }
+});
+
+test("api native exclude bypasses min-release-age", async ({expect = globalExpect}: any = {}) => {
+  const dir = await nativeCooldownDir("updates-native-exclude-", ".npmrc", "min-release-age=999999\nmin-release-age-exclude=noty\n");
+  try {
+    const output = await updates(apiOpts({files: [join(dir, "package.json")]}));
+    expect(output.results.npm.dependencies.noty.new).toBe("3.1.4");
+  } finally {
+    await rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100}).catch(() => {});
+  }
+});
+
+test("api native glob exclude bypasses min-release-age", async ({expect = globalExpect}: any = {}) => {
+  const dir = await nativeCooldownDir("updates-native-glob-", "pnpm-workspace.yaml", "minimumReleaseAge: 1440000000\nminimumReleaseAgeExclude:\n  - 'not*'\n");
+  try {
+    const output = await updates(apiOpts({files: [join(dir, "package.json")]}));
+    expect(output.results.npm.dependencies.noty.new).toBe("3.1.4");
+  } finally {
+    await rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100}).catch(() => {});
+  }
+});
+
+test("api explicit cooldown 0 disables native min-release-age", async ({expect = globalExpect}: any = {}) => {
+  const dir = await nativeCooldownDir("updates-native-zero-", ".npmrc", "min-release-age=999999\n");
+  try {
+    const output = await updates(apiOpts({files: [join(dir, "package.json")], cooldown: 0}));
+    expect(output.results.npm.dependencies.noty.new).toBe("3.1.4");
+  } finally {
+    await rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100}).catch(() => {});
+  }
+});
+
+test("api native quoted minimumReleaseAge holds back too-new version", async ({expect = globalExpect}: any = {}) => {
+  const dir = await nativeCooldownDir("updates-native-quoted-", "pnpm-workspace.yaml", "minimumReleaseAge: \"1440000000\"\n");
+  try {
+    const output = await updates(apiOpts({files: [join(dir, "package.json")]}));
+    expect(output.message).toBe("All dependencies are up to date.");
+  } finally {
+    await rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100}).catch(() => {});
+  }
+});
+
 test("api modes filter", async ({expect = globalExpect}: any = {}) => {
   const output = await updates(apiOpts({include: ["noty"], modes: ["pypi"]}));
   expect(output.message).toBe("No dependencies found, nothing to do.");

--- a/utils/pmCooldown.test.ts
+++ b/utils/pmCooldown.test.ts
@@ -1,0 +1,93 @@
+import {join} from "node:path";
+import {mkdtempSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {npmEcosystemCooldown} from "./pmCooldown.ts";
+
+const globalExpect = expect;
+const mkdir = (prefix: string) => mkdtempSync(join(tmpdir(), prefix));
+
+test("npmrc min-release-age in days", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-npm-");
+  writeFileSync(join(dir, ".npmrc"), "registry=https://example.com\nmin-release-age=3\n");
+  const {days, exclude} = npmEcosystemCooldown(dir);
+  expect(days).toBe(3);
+  expect(exclude.size).toBe(0);
+});
+
+test("npmrc min-release-age-exclude", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-npm-ex-");
+  writeFileSync(join(dir, ".npmrc"), "min-release-age=7\nmin-release-age-exclude=react, @scope/pkg\n");
+  const {days, exclude} = npmEcosystemCooldown(dir);
+  expect(days).toBe(7);
+  expect(Array.from(exclude).sort()).toEqual(["@scope/pkg", "react"]);
+});
+
+test("npmrc pnpm minimum-release-age in minutes", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-npm-min-");
+  writeFileSync(join(dir, ".npmrc"), "minimum-release-age=2880\n");
+  const {days} = npmEcosystemCooldown(dir);
+  expect(days).toBe(2); // 2880 minutes = 2 days
+});
+
+test("pnpm-workspace.yaml minimumReleaseAge with block exclude", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-pnpm-");
+  writeFileSync(join(dir, "pnpm-workspace.yaml"), [
+    "packages:",
+    "  - 'packages/*'",
+    "minimumReleaseAge: 1440",
+    "minimumReleaseAgeExclude:",
+    "  - react",
+    "  - '@myorg/*'",
+  ].join("\n"));
+  const {days, exclude} = npmEcosystemCooldown(dir);
+  expect(days).toBe(1); // 1440 minutes = 1 day
+  expect(Array.from(exclude).sort()).toEqual(["@myorg/*", "react"]);
+});
+
+test("pnpm-workspace.yaml inline array exclude", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-pnpm-inline-");
+  writeFileSync(join(dir, "pnpm-workspace.yaml"), "minimumReleaseAge: 720\nminimumReleaseAgeExclude: ['react', \"vue\"]\n");
+  const {days, exclude} = npmEcosystemCooldown(dir);
+  expect(days).toBe(0.5); // 720 minutes = half a day
+  expect(Array.from(exclude).sort()).toEqual(["react", "vue"]);
+});
+
+test("pnpm-workspace.yaml quoted minimumReleaseAge", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-pnpm-quoted-");
+  writeFileSync(join(dir, "pnpm-workspace.yaml"), "minimumReleaseAge: \"2880\"\n");
+  const {days} = npmEcosystemCooldown(dir);
+  expect(days).toBe(2); // 2880 minutes = 2 days, even when quoted
+});
+
+test("bunfig.toml minimumReleaseAge in seconds with excludes", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-bun-");
+  writeFileSync(join(dir, "bunfig.toml"), "[install]\nminimumReleaseAge = 259200\nminimumReleaseAgeExcludes = [\"react\", \"left-pad\"]\n");
+  const {days, exclude} = npmEcosystemCooldown(dir);
+  expect(days).toBe(3); // 259200 seconds = 3 days
+  expect(Array.from(exclude).sort()).toEqual(["left-pad", "react"]);
+});
+
+test("most conservative value and union of excludes across managers", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-all-");
+  writeFileSync(join(dir, ".npmrc"), "min-release-age=2\nmin-release-age-exclude=a\n");
+  writeFileSync(join(dir, "pnpm-workspace.yaml"), "minimumReleaseAge: 14400\nminimumReleaseAgeExclude:\n  - b\n"); // 10 days
+  writeFileSync(join(dir, "bunfig.toml"), "[install]\nminimumReleaseAge = 432000\nminimumReleaseAgeExcludes = [\"c\"]\n"); // 5 days
+  const {days, exclude} = npmEcosystemCooldown(dir);
+  expect(days).toBe(10); // max(2, 10, 5)
+  expect(Array.from(exclude).sort()).toEqual(["a", "b", "c"]);
+});
+
+test("no config files yields no constraint", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-none-");
+  const {days, exclude} = npmEcosystemCooldown(dir);
+  expect(days).toBe(0);
+  expect(exclude.size).toBe(0);
+});
+
+test("garbage files contribute nothing", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-garbage-");
+  writeFileSync(join(dir, ".npmrc"), "min-release-age=not-a-number\n");
+  writeFileSync(join(dir, "bunfig.toml"), "this is = [ not valid toml\n");
+  const {days} = npmEcosystemCooldown(dir);
+  expect(days).toBe(0);
+});

--- a/utils/pmCooldown.test.ts
+++ b/utils/pmCooldown.test.ts
@@ -67,6 +67,21 @@ test("bunfig.toml minimumReleaseAge in seconds with excludes", ({expect = global
   expect(Array.from(exclude).sort()).toEqual(["left-pad", "react"]);
 });
 
+test(".yarnrc.yml npmMinimalAgeGate in minutes with preapproved", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-yarn-");
+  writeFileSync(join(dir, ".yarnrc.yml"), "npmMinimalAgeGate: 4320\nnpmPreapprovedPackages:\n  - react\n  - \"@myorg/*\"\n");
+  const {days, exclude} = npmEcosystemCooldown(dir);
+  expect(days).toBe(3); // 4320 minutes = 3 days
+  expect(Array.from(exclude).sort()).toEqual(["@myorg/*", "react"]);
+});
+
+test(".yarnrc.yml npmMinimalAgeGate as duration string", ({expect = globalExpect}: any = {}) => {
+  const dir = mkdir("pmcd-yarn-dur-");
+  writeFileSync(join(dir, ".yarnrc.yml"), "npmMinimalAgeGate: \"7d\"\n");
+  const {days} = npmEcosystemCooldown(dir);
+  expect(days).toBe(7);
+});
+
 test("most conservative value and union of excludes across managers", ({expect = globalExpect}: any = {}) => {
   const dir = mkdir("pmcd-all-");
   writeFileSync(join(dir, ".npmrc"), "min-release-age=2\nmin-release-age-exclude=a\n");

--- a/utils/pmCooldown.ts
+++ b/utils/pmCooldown.ts
@@ -1,0 +1,142 @@
+import {readFileSync} from "node:fs";
+import {join, dirname} from "node:path";
+import {parseIni} from "./rc.ts";
+import {parseToml} from "./toml.ts";
+
+// Reads the native "minimum release age" supply-chain settings that npm, pnpm and
+// bun expose, so `updates` won't propose a version those package managers would
+// themselves refuse to install. All values are normalized to days.
+//
+// | PM   | file                  | key                  | unit    | exclude key                  |
+// |------|-----------------------|----------------------|---------|------------------------------|
+// | npm  | .npmrc                | min-release-age      | days    | min-release-age-exclude      |
+// | pnpm | .npmrc                | minimum-release-age  | minutes | minimum-release-age-exclude  |
+// | pnpm | pnpm-workspace.yaml   | minimumReleaseAge    | minutes | minimumReleaseAgeExclude     |
+// | bun  | bunfig.toml [install] | minimumReleaseAge    | seconds | minimumReleaseAgeExcludes    |
+
+export type NativeCooldown = {
+  /** Largest minimum age found, in days (0 if none). */
+  days: number;
+  /** Union of package names exempted from the minimum age. */
+  exclude: Set<string>;
+};
+
+function readUp(startDir: string, filename: string): string | undefined {
+  let dir = startDir;
+  while (true) {
+    try {
+      return readFileSync(join(dir, filename), "utf8");
+    } catch {}
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+function splitList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
+}
+
+// Parse `minimumReleaseAge` (minutes) and `minimumReleaseAgeExclude` from a
+// pnpm-workspace.yaml. Mirrors the minimal YAML extraction in parsePnpmWorkspace;
+// supports both inline (`[a, b]`) and block (`- a`) list forms for the exclude.
+function parsePnpmWorkspaceCooldown(content: string): {minutes?: number, exclude: string[]} {
+  let minutes: number | undefined;
+  const exclude: string[] = [];
+  let inExclude = false;
+  for (const line of content.split(/\r?\n/)) {
+    const scalar = /^minimumReleaseAge\s*:\s*['"]?(\d+(?:\.\d+)?)/.exec(line);
+    if (scalar) {
+      minutes = Number(scalar[1]);
+      inExclude = false;
+      continue;
+    }
+    const excludeKey = /^minimumReleaseAgeExclude\s*:(.*)$/.exec(line);
+    if (excludeKey) {
+      const inline = excludeKey[1].trim();
+      const arr = /^\[(.*)\]$/.exec(inline);
+      if (arr) {
+        for (const item of arr[1].split(",")) {
+          const m = /^\s*['"]?([^'"#\s]+)['"]?\s*$/.exec(item);
+          if (m) exclude.push(m[1]);
+        }
+        inExclude = false;
+      } else {
+        inExclude = true;
+      }
+      continue;
+    }
+    if (inExclude) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const item = /^-\s+['"]?([^'"#\s]+)['"]?/.exec(trimmed);
+      if (item) {
+        exclude.push(item[1]);
+      } else {
+        inExclude = false; // a non-list line ends the block
+      }
+    }
+  }
+  return {minutes, exclude};
+}
+
+function fromNpmrc(content: string): {days: number, exclude: string[]} {
+  const ini = parseIni(content);
+  let days = 0;
+  const npmDays = Number(ini["min-release-age"]);
+  if (Number.isFinite(npmDays) && npmDays > 0) days = Math.max(days, npmDays);
+  const pnpmMinutes = Number(ini["minimum-release-age"]);
+  if (Number.isFinite(pnpmMinutes) && pnpmMinutes > 0) days = Math.max(days, pnpmMinutes / 1440);
+  const exclude = [
+    ...splitList(ini["min-release-age-exclude"]),
+    ...splitList(ini["minimum-release-age-exclude"]),
+  ];
+  return {days, exclude};
+}
+
+function fromBunfig(content: string): {days: number, exclude: string[]} {
+  let parsed: Record<string, any>;
+  try {
+    parsed = parseToml(content) as Record<string, any>;
+  } catch {
+    return {days: 0, exclude: []};
+  }
+  const install = (parsed.install ?? {}) as Record<string, any>;
+  const seconds = Number(install.minimumReleaseAge ?? parsed.minimumReleaseAge);
+  const days = Number.isFinite(seconds) && seconds > 0 ? seconds / 86400 : 0;
+  const raw = install.minimumReleaseAgeExcludes ?? parsed.minimumReleaseAgeExcludes;
+  const exclude = Array.isArray(raw) ? raw.filter((n): n is string => typeof n === "string" && Boolean(n)) : [];
+  return {days, exclude};
+}
+
+/**
+ * Resolve the effective native minimum release age for an npm-ecosystem project,
+ * walking up from `projectDir` to find .npmrc, pnpm-workspace.yaml and bunfig.toml.
+ * When several settings are present the most conservative (max days, union of
+ * excludes) wins. Missing or unparseable files contribute nothing. Callers that
+ * look this up repeatedly should cache per run, since config files can change
+ * between separate invocations within a long-lived process.
+ */
+export function npmEcosystemCooldown(projectDir: string): NativeCooldown {
+  let days = 0;
+  const exclude = new Set<string>();
+  const merge = ({days: d, exclude: ex}: {days: number, exclude: string[]}) => {
+    if (d > days) days = d;
+    for (const name of ex) exclude.add(name);
+  };
+
+  const npmrc = readUp(projectDir, ".npmrc");
+  if (npmrc) merge(fromNpmrc(npmrc));
+
+  const pnpmWorkspace = readUp(projectDir, "pnpm-workspace.yaml");
+  if (pnpmWorkspace) {
+    const {minutes, exclude: ex} = parsePnpmWorkspaceCooldown(pnpmWorkspace);
+    merge({days: minutes && minutes > 0 ? minutes / 1440 : 0, exclude: ex});
+  }
+
+  const bunfig = readUp(projectDir, "bunfig.toml");
+  if (bunfig) merge(fromBunfig(bunfig));
+
+  return {days, exclude};
+}

--- a/utils/pmCooldown.ts
+++ b/utils/pmCooldown.ts
@@ -2,17 +2,19 @@ import {readFileSync} from "node:fs";
 import {join, dirname} from "node:path";
 import {parseIni} from "./rc.ts";
 import {parseToml} from "./toml.ts";
+import {parseDuration, esc} from "./utils.ts";
 
-// Reads the native "minimum release age" supply-chain settings that npm, pnpm and
-// bun expose, so `updates` won't propose a version those package managers would
-// themselves refuse to install. All values are normalized to days.
+// Reads the native "minimum release age" supply-chain settings that npm, pnpm,
+// bun and yarn expose, so `updates` won't propose a version those package
+// managers would themselves refuse to install. All values are normalized to days.
 //
-// | PM   | file                  | key                  | unit    | exclude key                  |
-// |------|-----------------------|----------------------|---------|------------------------------|
-// | npm  | .npmrc                | min-release-age      | days    | min-release-age-exclude      |
-// | pnpm | .npmrc                | minimum-release-age  | minutes | minimum-release-age-exclude  |
-// | pnpm | pnpm-workspace.yaml   | minimumReleaseAge    | minutes | minimumReleaseAgeExclude     |
-// | bun  | bunfig.toml [install] | minimumReleaseAge    | seconds | minimumReleaseAgeExcludes    |
+// | PM   | file                  | key                  | unit             | exclude key                  |
+// |------|-----------------------|----------------------|------------------|------------------------------|
+// | npm  | .npmrc                | min-release-age      | days             | min-release-age-exclude      |
+// | pnpm | .npmrc                | minimum-release-age  | minutes          | minimum-release-age-exclude  |
+// | pnpm | pnpm-workspace.yaml   | minimumReleaseAge    | minutes          | minimumReleaseAgeExclude     |
+// | bun  | bunfig.toml [install] | minimumReleaseAge    | seconds          | minimumReleaseAgeExcludes    |
+// | yarn | .yarnrc.yml           | npmMinimalAgeGate    | minutes or "7d"  | npmPreapprovedPackages       |
 
 export type NativeCooldown = {
   /** Largest minimum age found, in days (0 if none). */
@@ -38,47 +40,80 @@ function splitList(value: string | undefined): string[] {
   return value.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
 }
 
-// Parse `minimumReleaseAge` (minutes) and `minimumReleaseAgeExclude` from a
-// pnpm-workspace.yaml. Mirrors the minimal YAML extraction in parsePnpmWorkspace;
-// supports both inline (`[a, b]`) and block (`- a`) list forms for the exclude.
-function parsePnpmWorkspaceCooldown(content: string): {minutes?: number, exclude: string[]} {
-  let minutes: number | undefined;
-  const exclude: string[] = [];
-  let inExclude = false;
+// Extract a top-level scalar value for `key` from minimal YAML, with surrounding
+// quotes and trailing comments stripped. Returns undefined when the key is absent
+// or has no inline value (e.g. it heads a block list).
+function yamlScalar(content: string, key: string): string | undefined {
+  const re = new RegExp(`^${esc(key)}\\s*:[^\\S\\n]+(.+)$`);
   for (const line of content.split(/\r?\n/)) {
-    const scalar = /^minimumReleaseAge\s*:\s*['"]?(\d+(?:\.\d+)?)/.exec(line);
-    if (scalar) {
-      minutes = Number(scalar[1]);
-      inExclude = false;
-      continue;
+    const m = re.exec(line);
+    if (!m) continue;
+    let v = m[1].replace(/\s+#.*$/, "").trim();
+    if (v.length >= 2 && ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))) {
+      v = v.slice(1, -1);
     }
-    const excludeKey = /^minimumReleaseAgeExclude\s*:(.*)$/.exec(line);
-    if (excludeKey) {
-      const inline = excludeKey[1].trim();
+    return v || undefined;
+  }
+  return undefined;
+}
+
+// Extract a top-level sequence for `key` from minimal YAML, supporting both
+// inline (`[a, b]`) and block (`- a`) forms.
+function yamlList(content: string, key: string): string[] {
+  const out: string[] = [];
+  const headerRe = new RegExp(`^${esc(key)}\\s*:(.*)$`);
+  let inList = false;
+  for (const line of content.split(/\r?\n/)) {
+    const header = headerRe.exec(line);
+    if (header) {
+      const inline = header[1].trim();
       const arr = /^\[(.*)\]$/.exec(inline);
       if (arr) {
         for (const item of arr[1].split(",")) {
           const m = /^\s*['"]?([^'"#\s]+)['"]?\s*$/.exec(item);
-          if (m) exclude.push(m[1]);
+          if (m) out.push(m[1]);
         }
-        inExclude = false;
+        inList = false;
       } else {
-        inExclude = true;
+        inList = true;
       }
       continue;
     }
-    if (inExclude) {
+    if (inList) {
       const trimmed = line.trim();
       if (!trimmed || trimmed.startsWith("#")) continue;
       const item = /^-\s+['"]?([^'"#\s]+)['"]?/.exec(trimmed);
-      if (item) {
-        exclude.push(item[1]);
-      } else {
-        inExclude = false; // a non-list line ends the block
-      }
+      if (item) out.push(item[1]);
+      else inList = false; // a non-list line ends the block
     }
   }
-  return {minutes, exclude};
+  return out;
+}
+
+// pnpm-workspace.yaml: `minimumReleaseAge` is in minutes.
+function fromPnpmWorkspace(content: string): {days: number, exclude: string[]} {
+  const raw = yamlScalar(content, "minimumReleaseAge");
+  const minutes = raw !== undefined ? Number(raw) : NaN;
+  const days = Number.isFinite(minutes) && minutes > 0 ? minutes / 1440 : 0;
+  return {days, exclude: yamlList(content, "minimumReleaseAgeExclude")};
+}
+
+// .yarnrc.yml (Yarn 4.10+): `npmMinimalAgeGate` is minutes as a number, or a
+// duration string like "7d". `npmPreapprovedPackages` exempts packages.
+function fromYarnrc(content: string): {days: number, exclude: string[]} {
+  const raw = yamlScalar(content, "npmMinimalAgeGate");
+  let days = 0;
+  if (raw !== undefined) {
+    if (/^\d+(?:\.\d+)?$/.test(raw)) {
+      days = Number(raw) / 1440; // bare number is minutes
+    } else {
+      try {
+        const d = parseDuration(raw); // duration string like "7d" -> days
+        if (Number.isFinite(d) && d > 0) days = d;
+      } catch {}
+    }
+  }
+  return {days, exclude: yamlList(content, "npmPreapprovedPackages")};
 }
 
 function fromNpmrc(content: string): {days: number, exclude: string[]} {
@@ -130,13 +165,13 @@ export function npmEcosystemCooldown(projectDir: string): NativeCooldown {
   if (npmrc) merge(fromNpmrc(npmrc));
 
   const pnpmWorkspace = readUp(projectDir, "pnpm-workspace.yaml");
-  if (pnpmWorkspace) {
-    const {minutes, exclude: ex} = parsePnpmWorkspaceCooldown(pnpmWorkspace);
-    merge({days: minutes && minutes > 0 ? minutes / 1440 : 0, exclude: ex});
-  }
+  if (pnpmWorkspace) merge(fromPnpmWorkspace(pnpmWorkspace));
 
   const bunfig = readUp(projectDir, "bunfig.toml");
   if (bunfig) merge(fromBunfig(bunfig));
+
+  const yarnrc = readUp(projectDir, ".yarnrc.yml");
+  if (yarnrc) merge(fromYarnrc(yarnrc));
 
   return {days, exclude};
 }


### PR DESCRIPTION
### Summary

The npm ecosystem now ships built-in supply-chain "cooldown" settings — a minimum age a published version must reach before a package manager will install it. `updates` already has its own `cooldown` option, but ignored these native settings. This PR makes the **npm mode** automatically honor them, so `updates` never proposes a version the package manager itself would refuse to install.

The nearest config file above each manifest is read and normalized to days:

| Package manager | File                              | Setting (unit)                                        | Exclude list                                               |
| --------------- | --------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------- |
| npm             | `.npmrc`                          | `min-release-age` (days)                              | `min-release-age-exclude`                                  |
| pnpm            | `pnpm-workspace.yaml` or `.npmrc` | `minimumReleaseAge` / `minimum-release-age` (minutes) | `minimumReleaseAgeExclude` / `minimum-release-age-exclude` |
| bun             | `bunfig.toml` `[install]`         | `minimumReleaseAge` (seconds)                         | `minimumReleaseAgeExcludes`                                |

When several are present, the **most conservative age** and the **union of exclude lists** apply.

### Precedence

An explicit `updates` cooldown always wins; the native value is only a fallback when `updates` has none:

1. Per-package `overrides` cooldown
2. Global/per-dir `cooldown` (incl. `--cooldown`) — an explicit `0` disables the native fallback
3. Native package-manager setting (with its exclude list, which supports globs like `@myorg/*`)

This is on by default for the npm mode. Other modes (pypi, go, cargo, docker, make, actions) are unaffected. uv/pypi is intentionally left out for now — its `pyproject.toml` `exclude-newer` is an absolute timestamp rather than a relative age and needs a separate mechanism.