### PR TITLE
Support unquoted keys and single-quoted strings in JSON5 parser

### DIFF
--- a/utils/json5.test.ts
+++ b/utils/json5.test.ts
@@ -28,6 +28,46 @@ test("escaped quotes inside strings", () => {
   expect(parseJsonish(`{"a": "he said \\"hi\\""}`)).toEqual({a: 'he said "hi"'});
 });
 
+test("unquoted identifier keys", () => {
+  expect(parseJsonish(`{a: 1, $schema: "x", b_2: true, nil: null}`))
+    .toEqual({a: 1, $schema: "x", b_2: true, nil: null});
+});
+
+test("single-quoted strings", () => {
+  expect(parseJsonish(`{'a': 'x', b: ['y', 'z']}`)).toEqual({a: "x", b: ["y", "z"]});
+});
+
+test("escapes inside single-quoted strings", () => {
+  expect(parseJsonish(`{a: 'it\\'s', b: 'a"b', c: 'x\\ty'}`)).toEqual({a: "it's", b: 'a"b', c: "x\ty"});
+});
+
+test("identifier followed by colon across comment is quoted", () => {
+  expect(parseJsonish(`{a /* k */: 1}`)).toEqual({a: 1});
+});
+
+test("bare literals as values are not quoted", () => {
+  expect(parseJsonish(`{a: true, b: false, c: null}`)).toEqual({a: true, b: false, c: null});
+});
+
+test("full JSON5 renovate config", () => {
+  const text = `{
+    // renovate
+    extends: ['github>sxzz/renovate-config'],
+    automerge: true,
+    packageRules: [
+      {
+        matchManagers: ['github-actions'],
+        enabled: false,
+      },
+    ],
+  }`;
+  expect(parseJsonish(text)).toEqual({
+    extends: ["github>sxzz/renovate-config"],
+    automerge: true,
+    packageRules: [{matchManagers: ["github-actions"], enabled: false}],
+  });
+});
+
 test("JSONC (mixed comments + trailing commas)", () => {
   const text = `{
     // a comment

--- a/utils/json5.ts
+++ b/utils/json5.ts
@@ -1,14 +1,38 @@
 /**
- * Minimal JSON5/JSONC-tolerant parser. Strips line/block comments and
- * trailing commas, then defers to JSON.parse. Covers JSONC fully and the
- * common subset of JSON5 used in the wild; does not support unquoted keys
- * or single-quoted strings.
+ * Minimal JSON5/JSONC-tolerant parser. Strips line/block comments and trailing
+ * commas, converts single-quoted strings and unquoted identifier keys to their
+ * JSON equivalents, then defers to JSON.parse. Covers JSONC fully and the common
+ * subset of JSON5 used in the wild; does not support exotic escapes (\x, \0),
+ * hex/Infinity/NaN literals, or line continuations inside single-quoted strings.
  */
+const identStart = /[A-Za-z_$]/;
+const identPart = /[A-Za-z0-9_$]/;
+
 export function parseJsonish(text: string): unknown {
   let out = "";
   let i = 0;
   const n = text.length;
   let pendingComma = -1; // index in `out` of a comma that becomes trailing if the next token closes a container
+
+  // Skip whitespace and comments starting at index j, returning the next significant index.
+  function skipTrivia(j: number): number {
+    while (j < n) {
+      if (/\s/.test(text[j])) { j++; continue; }
+      if (text[j] === "/" && text[j + 1] === "/") {
+        j += 2;
+        while (j < n && text[j] !== "\n") j++;
+        continue;
+      }
+      if (text[j] === "/" && text[j + 1] === "*") {
+        j += 2;
+        while (j < n && (text[j] !== "*" || text[j + 1] !== "/")) j++;
+        j += 2;
+        continue;
+      }
+      break;
+    }
+    return j;
+  }
 
   while (i < n) {
     const ch = text[i];
@@ -27,6 +51,29 @@ export function parseJsonish(text: string): unknown {
           continue;
         }
         if (c === '"') break;
+      }
+      continue;
+    }
+
+    // Single-quoted string: re-emit as a double-quoted JSON string.
+    if (ch === "'") {
+      pendingComma = -1;
+      out += '"';
+      i++;
+      while (i < n) {
+        const c = text[i];
+        if (c === "\\") {
+          const next = text[i + 1];
+          if (next === "'") { out += "'"; i += 2; continue; } // \' -> '
+          if (next === "\n") { i += 2; continue; } // line continuation, drop
+          out += c;
+          if (i + 1 < n) { out += next; i += 2; } else { i++; }
+          continue;
+        }
+        if (c === '"') { out += '\\"'; i++; continue; } // escape embedded double quote
+        if (c === "'") { out += '"'; i++; break; } // closing quote
+        out += c;
+        i++;
       }
       continue;
     }
@@ -57,6 +104,15 @@ export function parseJsonish(text: string): unknown {
       pendingComma = -1;
       out += ch;
       i++;
+      continue;
+    }
+
+    // Unquoted identifier: a key if followed by ':', otherwise a literal (true/false/null).
+    if (identStart.test(ch)) {
+      pendingComma = -1;
+      let ident = "";
+      while (i < n && identPart.test(text[i])) { ident += text[i]; i++; }
+      out += text[skipTrivia(i)] === ":" ? JSON.stringify(ident) : ident;
       continue;
     }
 

--- a/utils/renovate.test.ts
+++ b/utils/renovate.test.ts
@@ -99,6 +99,21 @@ test("renovate.json5 with comments and trailing commas", async () => {
   expect(await loadRenovateConfig(dir)).toEqual({pin: {react: "^18.0.0"}});
 });
 
+test("renovate.json5 with unquoted keys and single-quoted strings", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json5"), `{
+    extends: ['github>sxzz/renovate-config'],
+    automerge: true,
+    packageRules: [
+      {
+        matchPackageNames: ['react'],
+        allowedVersions: '^18.0.0',
+      },
+    ],
+  }`);
+  expect(await loadRenovateConfig(dir)).toEqual({pin: {react: "^18.0.0"}});
+});
+
 test.each([".github", ".gitea", ".forgejo", ".gitlab"])("forge dir config in %s", async (forge) => {
   const dir = makeDir();
   mkdirSync(join(dir, forge));


### PR DESCRIPTION
`parseJsonish` previously only stripped comments and trailing commas, so renovate configs written as real JSON5 — unquoted identifier keys and single-quoted strings — failed with a raw `JSON.parse` error like:

```
Unable to parse renovate config .github/renovate.json5: Expected property name or '}' in JSON at position 4
```

This converts unquoted identifier keys (`extends:` → `"extends":`) and single-quoted strings (`'x'` → `"x"`) to their JSON equivalents before handing off to `JSON.parse`. Trailing commas and comments continue to work.

Added unit tests in `utils/json5.test.ts` and an end-to-end `renovate.json5` case in `utils/renovate.test.ts`.