### PR TITLE
Resolve Renovate `extends` presets from git forges

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -437,7 +437,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
   const modeConfigs: Record<string, ModeCtx> = {};
 
   async function resolveModeFilters(projectDir: string) {
-    const modeConfig = await loadConfig(projectDir);
+    const modeConfig = await loadConfig(projectDir, {noCache: config.noCache, timeout: config.timeout || fetchTimeout});
     const modeInclude = modeConfig.include?.length ? patternsToRegexSet([...(config.include ?? []), ...modeConfig.include]) : include;
     const modeExclude = modeConfig.exclude?.length ? patternsToRegexSet([...(config.exclude ?? []), ...modeConfig.exclude]) : exclude;
     const pin: Record<string, string> = {...modeConfig.pin, ...globalPin};
@@ -474,7 +474,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
   }
 
   async function resolveFileConfig(fileDir: string): Promise<FileFilters> {
-    const cfg = await loadConfig(fileDir);
+    const cfg = await loadConfig(fileDir, {noCache: config.noCache, timeout: config.timeout || fetchTimeout});
     const inc = cfg.include?.length ? patternsToRegexSet([...(config.include ?? []), ...cfg.include]) : include;
     const exc = cfg.exclude?.length ? patternsToRegexSet([...(config.exclude ?? []), ...cfg.exclude]) : exclude;
     return {include: inc, exclude: exc, pin: cfg.pin ?? {}, cooldownDays: cooldownDaysFor(cfg.cooldown)};

--- a/api.ts
+++ b/api.ts
@@ -435,9 +435,10 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
   const makeDepInfos: Array<MakeDepInfo> = [];
   type ModeCtx = {modeConfig: Config, projectDir: string, pin: Record<string, string>};
   const modeConfigs: Record<string, ModeCtx> = {};
+  const presetFetch = {noCache: config.noCache, timeout: config.timeout || fetchTimeout};
 
   async function resolveModeFilters(projectDir: string) {
-    const modeConfig = await loadConfig(projectDir, {noCache: config.noCache, timeout: config.timeout || fetchTimeout});
+    const modeConfig = await loadConfig(projectDir, presetFetch);
     const modeInclude = modeConfig.include?.length ? patternsToRegexSet([...(config.include ?? []), ...modeConfig.include]) : include;
     const modeExclude = modeConfig.exclude?.length ? patternsToRegexSet([...(config.exclude ?? []), ...modeConfig.exclude]) : exclude;
     const pin: Record<string, string> = {...modeConfig.pin, ...globalPin};
@@ -474,7 +475,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
   }
 
   async function resolveFileConfig(fileDir: string): Promise<FileFilters> {
-    const cfg = await loadConfig(fileDir, {noCache: config.noCache, timeout: config.timeout || fetchTimeout});
+    const cfg = await loadConfig(fileDir, presetFetch);
     const inc = cfg.include?.length ? patternsToRegexSet([...(config.include ?? []), ...cfg.include]) : include;
     const exc = cfg.exclude?.length ? patternsToRegexSet([...(config.exclude ?? []), ...cfg.exclude]) : exclude;
     return {include: inc, exclude: exc, pin: cfg.pin ?? {}, cooldownDays: cooldownDaysFor(cfg.cooldown)};

--- a/config.ts
+++ b/config.ts
@@ -4,6 +4,7 @@ import {access} from "node:fs/promises";
 import type {ParseArgsOptionsConfig} from "node:util";
 import {validRange} from "./utils/semver.ts";
 import {commaSeparatedToArray, esc, walkUp, memoizeAsync} from "./utils/utils.ts";
+import type {PresetFetchOptions} from "./utils/renovate.ts";
 
 export type Config = {
   /** Array of dependencies to include */
@@ -223,10 +224,11 @@ async function tryLoadInDir(dir: string): Promise<FoundConfig | null> {
 
 const findConfigUp = memoizeAsync((startDir: string) => walkUp(startDir, tryLoadInDir));
 
-export async function loadConfig(startDir: string): Promise<Config> {
+export async function loadConfig(startDir: string, presetFetch: PresetFetchOptions = {}): Promise<Config> {
   const found = await findConfigUp(startDir);
   const raw: Config = found?.default ?? {};
-  const {loadRenovateConfig} = await import("./utils/renovate.ts");
-  const renovateConfig = await loadRenovateConfig(found?.configDir ?? startDir, raw.inherit?.renovate);
+  const {loadRenovateConfig, makePresetFetcher} = await import("./utils/renovate.ts");
+  const fetchText = makePresetFetcher(presetFetch);
+  const renovateConfig = await loadRenovateConfig(found?.configDir ?? startDir, raw.inherit?.renovate, fetchText);
   return {...renovateConfig, ...raw};
 }

--- a/index.ts
+++ b/index.ts
@@ -173,7 +173,12 @@ async function main(): Promise<void> {
     await end();
   }
 
-  const fileConfig = await loadConfig(startDir);
+  // args are parsed here but config.noCache/timeout are set below, so derive the
+  // preset-fetch options straight from args for this initial load.
+  const fileConfig = await loadConfig(startDir, {
+    noCache: Boolean(args["no-cache"]),
+    timeout: (typeof args.timeout === "string" && Number(args.timeout)) || fetchTimeout,
+  });
   const useColor = resolveColor(fileConfig);
   if (useColor) {
     red = (text: string | number) => styleText("red", String(text));

--- a/utils/renovate.test.ts
+++ b/utils/renovate.test.ts
@@ -1,11 +1,17 @@
-import {test, expect, afterAll} from "vitest";
+import {test, expect, afterAll, vi} from "vitest";
 import {mkdtempSync, rmSync, mkdirSync, writeFileSync, copyFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
-import {loadRenovateConfig} from "./renovate.ts";
+import {loadRenovateConfig, makePresetFetcher, type PresetFetcher} from "./renovate.ts";
 
 const fixturesDir = fileURLToPath(new URL("../fixtures/renovate/", import.meta.url));
+
+// Adapt a synchronous URL→body resolver into a PresetFetcher, keeping mocks terse.
+const fetcher = (fn: (url: string) => string | null): PresetFetcher => (url) => Promise.resolve(fn(url));
+
+// Default preset fetcher for tests: resolves nothing, so no network is hit.
+const noFetch = fetcher(() => null);
 
 const created: Array<string> = [];
 
@@ -111,7 +117,151 @@ test("renovate.json5 with unquoted keys and single-quoted strings", async () => 
       },
     ],
   }`);
-  expect(await loadRenovateConfig(dir)).toEqual({pin: {react: "^18.0.0"}});
+  expect(await loadRenovateConfig(dir, {}, noFetch)).toEqual({pin: {react: "^18.0.0"}});
+});
+
+test("extends github preset is fetched and merged", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json5"), `{
+    extends: ['github>sxzz/renovate-config'],
+    ignoreDeps: ['local-dep'],
+  }`);
+  const fetched: Array<string> = [];
+  const fetchText = fetcher((url) => {
+    fetched.push(url);
+    if (url.endsWith("/default.json")) {
+      return JSON.stringify({
+        extends: ["config:recommended"], // built-in, skipped without network
+        ignoreDeps: ["node"],
+        packageRules: [{matchPackageNames: ["react"], allowedVersions: "^18"}],
+      });
+    }
+    return null;
+  });
+  expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({
+    exclude: ["node", "local-dep"],
+    pin: {react: "^18"},
+  });
+  expect(fetched[0]).toBe("https://raw.githubusercontent.com/sxzz/renovate-config/HEAD/default.json");
+});
+
+test("extends resolves recursively across presets", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({extends: ["github>org/a"]}));
+  const fetchText = fetcher((url) => {
+    if (url.includes("/org/a/")) return JSON.stringify({extends: ["github>org/b"], ignoreDeps: ["a"]});
+    if (url.includes("/org/b/")) return JSON.stringify({ignoreDeps: ["b"]});
+    return null;
+  });
+  expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["b", "a"]});
+});
+
+test("named preset reads presets[name] from the repo config, subpath fetches the file", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    extends: ["github>org/a:group", "gitlab>org/b//path/file"],
+  }));
+  const urls: Array<string> = [];
+  const fetchText = fetcher((url) => {
+    urls.push(url);
+    // named preset `:group` comes from the repo's default.json presets map, not group.json
+    if (url.endsWith("/org/a/HEAD/default.json")) return JSON.stringify({presets: {group: {ignoreDeps: ["g"]}}});
+    if (url.endsWith("/org/b/-/raw/HEAD/path/file.json")) return JSON.stringify({ignoreDeps: ["f"]});
+    return null;
+  });
+  expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["g", "f"]});
+  expect(urls).toContain("https://raw.githubusercontent.com/org/a/HEAD/default.json");
+  expect(urls).toContain("https://gitlab.com/org/b/-/raw/HEAD/path/file.json");
+  expect(urls).not.toContain("https://raw.githubusercontent.com/org/a/HEAD/group.json");
+});
+
+test("named preset missing from the config is skipped (does not fall back to whole config)", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    extends: ["github>org/a:foo"],
+    ignoreDeps: ["own"],
+  }));
+  const fetchText = fetcher((url) => {
+    // default.json exists but has no `foo` preset → Renovate would not apply the whole config
+    if (url.endsWith("/default.json")) return JSON.stringify({ignoreDeps: ["should-not-apply"]});
+    return null;
+  });
+  expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["own"]});
+});
+
+test("built-in and unresolvable presets are skipped without fetching", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    extends: ["config:recommended", "local>org/a", "gitea>org/b", "forgejo>org/c"],
+    ignoreDeps: ["own"],
+  }));
+  let called = false;
+  const fetchText = fetcher(() => { called = true; return null; });
+  expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["own"]});
+  expect(called).toBe(false);
+});
+
+test("unreachable preset is skipped, local config still applies", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    extends: ["github>org/a"],
+    ignoreDeps: ["own"],
+  }));
+  expect(await loadRenovateConfig(dir, {}, noFetch)).toEqual({exclude: ["own"]}); // every fetch fails
+});
+
+test("extends cycles terminate", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({extends: ["github>org/a"]}));
+  const fetchText = fetcher((url) => {
+    if (url.includes("/org/a/")) return JSON.stringify({extends: ["github>org/b"], ignoreDeps: ["a"]});
+    if (url.includes("/org/b/")) return JSON.stringify({extends: ["github>org/a"], ignoreDeps: ["b"]});
+    return null;
+  });
+  expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["b", "a"]});
+});
+
+test("inherited-key forges (__proto__, constructor) are skipped, not fetched", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    extends: ["__proto__>org/a", "constructor>org/b"],
+    ignoreDeps: ["own"],
+  }));
+  let called = false;
+  const fetchText = fetcher(() => { called = true; return null; });
+  expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["own"]});
+  expect(called).toBe(false);
+});
+
+test("diamond extends resolves the shared preset on each path", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({extends: ["github>org/a", "github>org/b"]}));
+  const fetchText = fetcher((url) => {
+    if (url.includes("/org/a/")) return JSON.stringify({extends: ["github>org/c"], ignoreDeps: ["a"]});
+    if (url.includes("/org/b/")) return JSON.stringify({extends: ["github>org/c"], ignoreDeps: ["b"]});
+    if (url.includes("/org/c/")) return JSON.stringify({ignoreDeps: ["c"]});
+    return null;
+  });
+  // c is reached via both a and b (path-scoped seen), so it contributes on each path.
+  expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["c", "a", "c", "b"]});
+});
+
+test("makePresetFetcher returns null (not throw) when the body read fails", async () => {
+  const fetchText = makePresetFetcher({noCache: true});
+  vi.stubGlobal("fetch", () => Promise.resolve({
+    ok: true, status: 200, headers: new Headers(), text: () => Promise.reject(new Error("reset")),
+  }));
+  expect(await fetchText("https://example.com/x")).toBe(null);
+  vi.unstubAllGlobals();
+});
+
+test("makePresetFetcher returns null on a non-ok response with no cache", async () => {
+  const fetchText = makePresetFetcher({noCache: true});
+  vi.stubGlobal("fetch", () => Promise.resolve({
+    ok: false, status: 503, headers: new Headers(), text: () => Promise.resolve(""),
+  }));
+  expect(await fetchText("https://example.com/y")).toBe(null);
+  vi.unstubAllGlobals();
 });
 
 test.each([".github", ".gitea", ".forgejo", ".gitlab"])("forge dir config in %s", async (forge) => {

--- a/utils/renovate.test.ts
+++ b/utils/renovate.test.ts
@@ -1,4 +1,4 @@
-import {test, expect, afterAll, vi} from "vitest";
+import {test, expect, afterAll} from "vitest";
 import {mkdtempSync, rmSync, mkdirSync, writeFileSync, copyFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
@@ -192,13 +192,43 @@ test("named preset missing from the config is skipped (does not fall back to who
 test("built-in and unresolvable presets are skipped without fetching", async () => {
   const dir = makeDir();
   writeFileSync(join(dir, "renovate.json"), JSON.stringify({
-    extends: ["config:recommended", "local>org/a", "gitea>org/b", "forgejo>org/c"],
+    extends: ["config:recommended", ":pinVersions", "local>org/a", "bitbucket>org/b"],
     ignoreDeps: ["own"],
   }));
   let called = false;
   const fetchText = fetcher(() => { called = true; return null; });
   expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["own"]});
   expect(called).toBe(false);
+});
+
+test("gitea and forgejo presets resolve against their default endpoints", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    extends: ["gitea>org/a", "forgejo>org/b"],
+  }));
+  const urls: Array<string> = [];
+  const fetchText = fetcher((url) => {
+    urls.push(url);
+    if (url === "https://gitea.com/api/v1/repos/org/a/raw/default.json?ref=HEAD") return JSON.stringify({ignoreDeps: ["gt"]});
+    if (url === "https://code.forgejo.org/api/v1/repos/org/b/raw/default.json?ref=HEAD") return JSON.stringify({ignoreDeps: ["fj"]});
+    return null;
+  });
+  expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["gt", "fj"]});
+});
+
+test("http preset is fetched directly as a single file", async () => {
+  const dir = makeDir();
+  writeFileSync(join(dir, "renovate.json"), JSON.stringify({
+    extends: ["https://git.example.com/org/repo/raw/branch/main/renovate.json"],
+    ignoreDeps: ["own"],
+  }));
+  const urls: Array<string> = [];
+  const fetchText = fetcher((url) => {
+    urls.push(url);
+    return JSON.stringify({ignoreDeps: ["remote"]});
+  });
+  expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["remote", "own"]});
+  expect(urls).toEqual(["https://git.example.com/org/repo/raw/branch/main/renovate.json"]);
 });
 
 test("unreachable preset is skipped, local config still applies", async () => {
@@ -246,22 +276,32 @@ test("diamond extends resolves the shared preset on each path", async () => {
   expect(await loadRenovateConfig(dir, {}, fetchText)).toEqual({exclude: ["c", "a", "c", "b"]});
 });
 
+// Swap globalThis.fetch directly (not vi.stubGlobal, which bun's test runner lacks).
+async function withFetch(impl: typeof fetch, fn: () => Promise<void>): Promise<void> {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl;
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
 test("makePresetFetcher returns null (not throw) when the body read fails", async () => {
   const fetchText = makePresetFetcher({noCache: true});
-  vi.stubGlobal("fetch", () => Promise.resolve({
+  const impl = (() => Promise.resolve({
     ok: true, status: 200, headers: new Headers(), text: () => Promise.reject(new Error("reset")),
-  }));
-  expect(await fetchText("https://example.com/x")).toBe(null);
-  vi.unstubAllGlobals();
+  })) as unknown as typeof fetch;
+  await withFetch(impl, async () => {
+    expect(await fetchText("https://example.com/x")).toBe(null);
+  });
 });
 
 test("makePresetFetcher returns null on a non-ok response with no cache", async () => {
   const fetchText = makePresetFetcher({noCache: true});
-  vi.stubGlobal("fetch", () => Promise.resolve({
-    ok: false, status: 503, headers: new Headers(), text: () => Promise.resolve(""),
-  }));
-  expect(await fetchText("https://example.com/y")).toBe(null);
-  vi.unstubAllGlobals();
+  await withFetch(() => Promise.resolve(new Response(null, {status: 503})), async () => {
+    expect(await fetchText("https://example.com/y")).toBe(null);
+  });
 });
 
 test.each([".github", ".gitea", ".forgejo", ".gitlab"])("forge dir config in %s", async (forge) => {

--- a/utils/renovate.test.ts
+++ b/utils/renovate.test.ts
@@ -206,9 +206,8 @@ test("gitea and forgejo presets resolve against their default endpoints", async 
   writeFileSync(join(dir, "renovate.json"), JSON.stringify({
     extends: ["gitea>org/a", "forgejo>org/b"],
   }));
-  const urls: Array<string> = [];
+  // Only the exact default-endpoint URLs return content, so a pass proves the URLs.
   const fetchText = fetcher((url) => {
-    urls.push(url);
     if (url === "https://gitea.com/api/v1/repos/org/a/raw/default.json?ref=HEAD") return JSON.stringify({ignoreDeps: ["gt"]});
     if (url === "https://code.forgejo.org/api/v1/repos/org/b/raw/default.json?ref=HEAD") return JSON.stringify({ignoreDeps: ["fj"]});
     return null;

--- a/utils/renovate.ts
+++ b/utils/renovate.ts
@@ -149,30 +149,38 @@ function normalize(raw: RenovateConfig, opts: RenovateImportOptions): Partial<Co
 /** Fetch a preset file as text, or null if missing/unreachable. Injectable for tests. */
 export type PresetFetcher = (url: string) => Promise<string | null>;
 
-// Only git-forge presets with a known public host are resolvable. gitea>/forgejo>
-// need a self-hosted endpoint and local> needs the running platform, neither of
-// which exists here; built-in presets (config:, :x, helpers:, group:, …) are
-// bundled inside Renovate itself and have no URL. All of those are skipped.
+// Forge presets resolve against a fixed public endpoint (as Renovate does): the
+// host is never part of the `forge>` string. gitea>/forgejo> point at gitea.com /
+// code.forgejo.org, matching Renovate's default endpoints. A self-hosted instance
+// is reached instead via an `http` preset (a full raw URL). local> needs the
+// running platform and built-in presets (config:, :x, helpers:, …) have no URL;
+// both are skipped.
 const forgeRawUrl: Record<string, (slug: string, ref: string, file: string) => string> = {
   github: (slug, ref, file) => `https://raw.githubusercontent.com/${slug}/${ref}/${file}`,
   gitlab: (slug, ref, file) => `https://gitlab.com/${slug}/-/raw/${ref}/${file}`,
+  gitea: (slug, ref, file) => `https://gitea.com/api/v1/repos/${slug}/raw/${file}?ref=${ref}`,
+  forgejo: (slug, ref, file) => `https://code.forgejo.org/api/v1/repos/${slug}/raw/${file}?ref=${ref}`,
 };
 
 const maxPresetDepth = 10;
 
-type PresetLocation = {forge: string, slug: string, ref: string, name?: string, subpath?: string};
+type PresetLocation =
+  {kind: "forge", forge: string, slug: string, ref: string, name?: string, subpath?: string} |
+  {kind: "http", url: string};
 
 /**
  * Parse a Renovate preset reference into a fetchable location, or null if it is
- * a built-in or otherwise unresolvable preset. Handles `forge>owner/repo`,
- * `:preset` names, `//path` subpaths, `#ref` refs and `(params)` (params ignored).
+ * a built-in or otherwise unresolvable preset. Handles a full `http(s)://` URL,
+ * `forge>owner/repo`, `:preset` names, `//path` subpaths, `#ref` refs and
+ * `(params)` (params ignored).
  */
 function parsePreset(preset: string): PresetLocation | null {
+  if (/^https?:\/\//i.test(preset)) return {kind: "http", url: preset}; // custom-FQDN raw preset file
   const gt = preset.indexOf(">");
   if (gt === -1) return null; // built-in preset, no URL
   const forge = preset.slice(0, gt);
   // Object.hasOwn, not `in`: `in` matches inherited keys like __proto__/constructor.
-  if (!Object.hasOwn(forgeRawUrl, forge)) return null; // local>, gitea>, forgejo>, unknown host
+  if (!Object.hasOwn(forgeRawUrl, forge)) return null; // local>, unknown forge
   let rest = preset.slice(gt + 1).replace(/\([^)]*\)\s*$/, ""); // drop params, unsupported
   let ref = "HEAD";
   const hash = rest.indexOf("#");
@@ -189,7 +197,7 @@ function parsePreset(preset: string): PresetLocation | null {
   }
   const slug = rest.replace(/\/+$/, "");
   if (!slug.includes("/")) return null;
-  return {forge, slug, ref, name, subpath};
+  return {kind: "forge", forge, slug, ref, name, subpath};
 }
 
 // Repo config files Renovate probes, in order, to locate a preset's source.
@@ -212,6 +220,9 @@ function tryParse(body: string | null): RenovateConfig | null {
 }
 
 async function fetchPresetConfig(loc: PresetLocation, fetchText: PresetFetcher): Promise<RenovateConfig | null> {
+  // An `http` preset is a full URL to a single file; the whole document is the preset.
+  if (loc.kind === "http") return tryParse(await fetchText(loc.url));
+
   const build = forgeRawUrl[loc.forge];
   const fetchParsed = async (file: string) => tryParse(await fetchText(build(loc.slug, loc.ref, file)));
 
@@ -277,15 +288,29 @@ export type PresetFetchOptions = {noCache?: boolean, timeout?: number};
 // stall startup the way a fixed 30s per candidate file did.
 const defaultPresetTimeout = 10000;
 
+// Host-based auth for private presets, matching Renovate's hostRules model. Reuses
+// updates' token resolution (UPDATES_FORGE_TOKENS per host, plus GitHub env/`gh`
+// tokens). Imported lazily so config loads without presets pull in nothing.
+async function presetAuthToken(url: string): Promise<string | undefined> {
+  let hostname: string;
+  try { hostname = new URL(url).hostname; } catch { return undefined; }
+  const {getForgeTokens} = await import("../modes/shared.ts");
+  const [token] = await getForgeTokens(hostname, "https://api.github.com");
+  return token;
+}
+
 /**
  * Build the production preset fetcher: ETag-revalidated, honoring `noCache` and
- * `timeout`. Any network or body-read failure falls back to the cached copy (or
- * null), so a preset fetch never throws into config loading.
+ * `timeout`, sending a host token when one is configured. Any network or body-read
+ * failure falls back to the cached copy (or null), so a preset fetch never throws
+ * into config loading.
  */
 export function makePresetFetcher({noCache = false, timeout = defaultPresetTimeout}: PresetFetchOptions = {}): PresetFetcher {
   return async (url) => {
     const cached = noCache ? null : await getCache(url);
     const headers: Record<string, string> = {"user-agent": "updates"};
+    const token = await presetAuthToken(url);
+    if (token) headers.authorization = `Bearer ${token}`;
     if (cached) headers["if-none-match"] = cached.etag;
     let res: Response;
     try {

--- a/utils/renovate.ts
+++ b/utils/renovate.ts
@@ -236,10 +236,10 @@ async function fetchPresetConfig(loc: PresetLocation, fetchText: PresetFetcher):
   }
   // Otherwise Renovate reads the repo's first existing config file, then selects
   // the preset out of it: `presets[name]`, or the whole config for the default preset.
+  const name = loc.name ?? "default";
   for (const file of presetConfigFiles) {
     const parsed = await fetchParsed(file);
     if (!parsed) continue;
-    const name = loc.name ?? "default";
     const sub = parsed.presets?.[name];
     if (sub && typeof sub === "object") return sub;
     return loc.name ? null : parsed; // named-but-missing → skip; default → whole config
@@ -288,15 +288,18 @@ export type PresetFetchOptions = {noCache?: boolean, timeout?: number};
 // stall startup the way a fixed 30s per candidate file did.
 const defaultPresetTimeout = 10000;
 
-// Host-based auth for private presets, matching Renovate's hostRules model. Reuses
-// updates' token resolution (UPDATES_FORGE_TOKENS per host, plus GitHub env/`gh`
-// tokens). Imported lazily so config loads without presets pull in nothing.
-async function presetAuthToken(url: string): Promise<string | undefined> {
-  let hostname: string;
-  try { hostname = new URL(url).hostname; } catch { return undefined; }
-  const {getForgeTokens} = await import("../modes/shared.ts");
-  const [token] = await getForgeTokens(hostname, "https://api.github.com");
-  return token;
+// Build request headers (shared user-agent/encoding via getFetchOpts) plus a host
+// token for private presets, matching Renovate's hostRules model. Reuses updates'
+// token resolution (UPDATES_FORGE_TOKENS per host, plus GitHub env/`gh` tokens),
+// imported lazily so config loads without presets pull in nothing.
+async function presetHeaders(url: string, etag?: string): Promise<Record<string, string>> {
+  let hostname = "";
+  try { hostname = new URL(url).hostname; } catch {}
+  const {getForgeTokens, getFetchOpts} = await import("../modes/shared.ts");
+  const [token] = hostname ? await getForgeTokens(hostname, "https://api.github.com") : [];
+  const headers = {...getFetchOpts("Bearer", token).headers} as Record<string, string>;
+  if (etag) headers["if-none-match"] = etag;
+  return headers;
 }
 
 /**
@@ -308,10 +311,7 @@ async function presetAuthToken(url: string): Promise<string | undefined> {
 export function makePresetFetcher({noCache = false, timeout = defaultPresetTimeout}: PresetFetchOptions = {}): PresetFetcher {
   return async (url) => {
     const cached = noCache ? null : await getCache(url);
-    const headers: Record<string, string> = {"user-agent": "updates"};
-    const token = await presetAuthToken(url);
-    if (token) headers.authorization = `Bearer ${token}`;
-    if (cached) headers["if-none-match"] = cached.etag;
+    const headers = await presetHeaders(url, cached?.etag);
     let res: Response;
     try {
       res = await fetch(url, {headers, signal: AbortSignal.timeout(timeout)});

--- a/utils/renovate.ts
+++ b/utils/renovate.ts
@@ -3,6 +3,7 @@ import {readFile} from "node:fs/promises";
 import {parseJsonish} from "./json5.ts";
 import {validRange} from "./semver.ts";
 import {walkUp, memoizeAsync} from "./utils.ts";
+import {getCache, setCache} from "./fetchCache.ts";
 import type {Config} from "../config.ts";
 
 const forgeDirs = [".github", ".gitea", ".forgejo", ".gitlab"];
@@ -42,9 +43,11 @@ function parseRenovateDuration(str: string): number | undefined {
 }
 
 type RenovateConfig = {
+  extends?: Array<string>;
   minimumReleaseAge?: string;
   ignoreDeps?: Array<string>;
   packageRules?: Array<RenovatePackageRule>;
+  presets?: Record<string, RenovateConfig>;
   [key: string]: unknown;
 };
 
@@ -73,10 +76,10 @@ async function readFirstExisting(rootDir: string): Promise<{path: string, text: 
     } catch {}
   }
   try {
-    const text = await readFile(join(rootDir, "package.json"), "utf8");
-    const pkg = JSON.parse(text);
+    const pkgPath = join(rootDir, "package.json");
+    const pkg = JSON.parse(await readFile(pkgPath, "utf8"));
     if (pkg && typeof pkg === "object" && pkg.renovate && typeof pkg.renovate === "object") {
-      return {path: "package.json", text: JSON.stringify(pkg.renovate)};
+      return {path: pkgPath, text: JSON.stringify(pkg.renovate)};
     }
   } catch {}
   return undefined;
@@ -143,6 +146,167 @@ function normalize(raw: RenovateConfig, opts: RenovateImportOptions): Partial<Co
   return out;
 }
 
+/** Fetch a preset file as text, or null if missing/unreachable. Injectable for tests. */
+export type PresetFetcher = (url: string) => Promise<string | null>;
+
+// Only git-forge presets with a known public host are resolvable. gitea>/forgejo>
+// need a self-hosted endpoint and local> needs the running platform, neither of
+// which exists here; built-in presets (config:, :x, helpers:, group:, …) are
+// bundled inside Renovate itself and have no URL. All of those are skipped.
+const forgeRawUrl: Record<string, (slug: string, ref: string, file: string) => string> = {
+  github: (slug, ref, file) => `https://raw.githubusercontent.com/${slug}/${ref}/${file}`,
+  gitlab: (slug, ref, file) => `https://gitlab.com/${slug}/-/raw/${ref}/${file}`,
+};
+
+const maxPresetDepth = 10;
+
+type PresetLocation = {forge: string, slug: string, ref: string, name?: string, subpath?: string};
+
+/**
+ * Parse a Renovate preset reference into a fetchable location, or null if it is
+ * a built-in or otherwise unresolvable preset. Handles `forge>owner/repo`,
+ * `:preset` names, `//path` subpaths, `#ref` refs and `(params)` (params ignored).
+ */
+function parsePreset(preset: string): PresetLocation | null {
+  const gt = preset.indexOf(">");
+  if (gt === -1) return null; // built-in preset, no URL
+  const forge = preset.slice(0, gt);
+  // Object.hasOwn, not `in`: `in` matches inherited keys like __proto__/constructor.
+  if (!Object.hasOwn(forgeRawUrl, forge)) return null; // local>, gitea>, forgejo>, unknown host
+  let rest = preset.slice(gt + 1).replace(/\([^)]*\)\s*$/, ""); // drop params, unsupported
+  let ref = "HEAD";
+  const hash = rest.indexOf("#");
+  if (hash !== -1) { ref = rest.slice(hash + 1) || "HEAD"; rest = rest.slice(0, hash); }
+  let subpath: string | undefined;
+  let name: string | undefined;
+  const dslash = rest.indexOf("//");
+  if (dslash !== -1) {
+    subpath = rest.slice(dslash + 2);
+    rest = rest.slice(0, dslash);
+  } else {
+    const colon = rest.indexOf(":");
+    if (colon !== -1) { name = rest.slice(colon + 1); rest = rest.slice(0, colon); }
+  }
+  const slug = rest.replace(/\/+$/, "");
+  if (!slug.includes("/")) return null;
+  return {forge, slug, ref, name, subpath};
+}
+
+// Repo config files Renovate probes, in order, to locate a preset's source.
+const presetConfigFiles = ["default.json", "default.json5", "renovate.json", "renovate.json5", ".renovaterc.json", ".renovaterc"];
+
+// Candidate paths for an explicit `//subpath` preset, appending .json/.json5 when extensionless.
+function subpathFiles(subpath: string): Array<string> {
+  return /\.json5?$/.test(subpath) ? [subpath] : [`${subpath}.json`, `${subpath}.json5`];
+}
+
+// A null body (missing/unreachable) or unparseable body is skipped, never fatal.
+function tryParse(body: string | null): RenovateConfig | null {
+  if (body === null) return null;
+  try {
+    const parsed = parseJsonish(body);
+    return parsed && typeof parsed === "object" ? parsed as RenovateConfig : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchPresetConfig(loc: PresetLocation, fetchText: PresetFetcher): Promise<RenovateConfig | null> {
+  const build = forgeRawUrl[loc.forge];
+  const fetchParsed = async (file: string) => tryParse(await fetchText(build(loc.slug, loc.ref, file)));
+
+  // An explicit `//path` points straight at a file.
+  if (loc.subpath) {
+    for (const file of subpathFiles(loc.subpath)) {
+      const parsed = await fetchParsed(file);
+      if (parsed) return parsed;
+    }
+    return null;
+  }
+  // Otherwise Renovate reads the repo's first existing config file, then selects
+  // the preset out of it: `presets[name]`, or the whole config for the default preset.
+  for (const file of presetConfigFiles) {
+    const parsed = await fetchParsed(file);
+    if (!parsed) continue;
+    const name = loc.name ?? "default";
+    const sub = parsed.presets?.[name];
+    if (sub && typeof sub === "object") return sub;
+    return loc.name ? null : parsed; // named-but-missing → skip; default → whole config
+  }
+  return null;
+}
+
+// Concatenate arrays (packageRules, ignoreDeps), let scalars from `over` win.
+function mergeRenovate(base: RenovateConfig, over: RenovateConfig): RenovateConfig {
+  const out: RenovateConfig = {...base};
+  for (const [key, value] of Object.entries(over)) {
+    const prev = out[key];
+    out[key] = Array.isArray(value) && Array.isArray(prev) ? [...prev, ...value] : value;
+  }
+  return out;
+}
+
+/**
+ * Recursively resolve `extends` presets and merge them ahead of the config's own
+ * fields (which take precedence), mirroring Renovate. Fetch failures are skipped
+ * so an unreachable preset never blocks a build. `seen` is the current resolution
+ * path (cloned per branch) so cycles are caught while diamonds still resolve on
+ * each path, matching Renovate's path-scoped recursion.
+ */
+async function resolveExtends(
+  cfg: RenovateConfig, fetchText: PresetFetcher, seen: Set<string>, depth: number,
+): Promise<RenovateConfig> {
+  let merged: RenovateConfig = {};
+  const presets = Array.isArray(cfg.extends) ? cfg.extends : [];
+  for (const preset of presets) {
+    if (typeof preset !== "string" || depth >= maxPresetDepth || seen.has(preset)) continue;
+    const loc = parsePreset(preset);
+    if (!loc) continue;
+    const raw = await fetchPresetConfig(loc, fetchText);
+    if (raw) merged = mergeRenovate(merged, await resolveExtends(raw, fetchText, new Set(seen).add(preset), depth + 1));
+  }
+  const {extends: _extends, ...own} = cfg;
+  return mergeRenovate(merged, own);
+}
+
+/** Options controlling the production preset fetcher, mirroring the CLI's cache/timeout flags. */
+export type PresetFetchOptions = {noCache?: boolean, timeout?: number};
+
+// Fallback only for direct API callers; the CLI always passes the resolved
+// config.timeout (default 5000). Kept bounded so a hanging preset host can never
+// stall startup the way a fixed 30s per candidate file did.
+const defaultPresetTimeout = 10000;
+
+/**
+ * Build the production preset fetcher: ETag-revalidated, honoring `noCache` and
+ * `timeout`. Any network or body-read failure falls back to the cached copy (or
+ * null), so a preset fetch never throws into config loading.
+ */
+export function makePresetFetcher({noCache = false, timeout = defaultPresetTimeout}: PresetFetchOptions = {}): PresetFetcher {
+  return async (url) => {
+    const cached = noCache ? null : await getCache(url);
+    const headers: Record<string, string> = {"user-agent": "updates"};
+    if (cached) headers["if-none-match"] = cached.etag;
+    let res: Response;
+    try {
+      res = await fetch(url, {headers, signal: AbortSignal.timeout(timeout)});
+    } catch {
+      return cached?.body ?? null; // offline / connect failure
+    }
+    if (res.status === 304 && cached) return cached.body;
+    if (!res.ok) return cached?.body ?? null; // server error / rate-limit: prefer cache over dropping
+    let body: string;
+    try {
+      body = await res.text();
+    } catch {
+      return cached?.body ?? null; // mid-stream abort/reset
+    }
+    const etag = res.headers.get("etag");
+    if (etag && !noCache) setCache(url, etag, body);
+    return body;
+  };
+}
+
 type RenovateRaw = {parsed: RenovateConfig, path: string};
 
 const findRenovateUp = memoizeAsync((startDir: string) => walkUp(startDir, async (dir): Promise<RenovateRaw | null> => {
@@ -158,8 +322,20 @@ const findRenovateUp = memoizeAsync((startDir: string) => walkUp(startDir, async
   return {parsed: raw as RenovateConfig, path: found.path};
 }));
 
-export async function loadRenovateConfig(rootDir: string, opts: RenovateImportOptions = {}): Promise<Partial<Config>> {
+// Resolving `extends` is network I/O, so memoize per config-file path: a monorepo
+// whose packages share one renovate config resolves its presets once per process,
+// mirroring findRenovateUp. `opts` (cooldown) is applied per call after the cache.
+const resolvedExtendsCache = new Map<string, Promise<RenovateConfig>>();
+
+export async function loadRenovateConfig(
+  rootDir: string, opts: RenovateImportOptions = {}, fetchText: PresetFetcher = makePresetFetcher(),
+): Promise<Partial<Config>> {
   const found = await findRenovateUp(rootDir);
   if (!found) return {};
-  return normalize(found.parsed, opts);
+  let resolved = resolvedExtendsCache.get(found.path);
+  if (!resolved) {
+    resolved = resolveExtends(found.parsed, fetchText, new Set(), 0);
+    resolvedExtendsCache.set(found.path, resolved);
+  }
+  return normalize(await resolved, opts);
 }


### PR DESCRIPTION
Renovate configs commonly delegate their real `ignoreDeps`/`packageRules` to a shared preset via `extends: ['github>owner/repo']`. Those were ignored, so a config that only extends a preset (like tsdown's, which extends `github>sxzz/renovate-config`) contributed nothing to `updates`.

## What it does

Replicates Renovate's forge preset mechanism (verified against Renovate's `lib/config/presets` sources):

- Resolves `github>`, `gitlab>`, `gitea>` and `forgejo>` presets recursively. As in Renovate, each forge resolves against a fixed public endpoint — `gitea.com`, `code.forgejo.org` — the host is never part of the preset string.
- Supports a full `http(s)://` URL preset, fetched directly as a single file. This is Renovate's `http` source and the way to reference a self-hosted / custom-FQDN instance (there is no `local>` equivalent — that needs a running platform we don't have, so `local>` and built-ins like `config:` are skipped).
- Handles named (`:name`), subpath (`//path`) and `#ref` forms. Named presets read `presets[name]` from the repo's config file (Renovate's behavior), not a `<name>.json` file.
- Merges resolved presets ahead of the local config (local wins), into `exclude`/`pin`/`cooldown`.

## Auth

Private presets are authenticated with a host token, matching Renovate's hostRules model, reusing `getForgeTokens` — `UPDATES_FORGE_TOKENS` per host plus GitHub env/`gh` tokens. The token helper is imported lazily so a preset-less config pulls in nothing. (Note: GitHub tokens are not sent to `raw.githubusercontent.com`, consistent with the existing token-scoping policy, so private GitHub presets over the raw host are unauthenticated.)

## Robustness

- Fetches are ETag-revalidated and honor `--no-cache` / `--timeout` (threaded through `loadConfig`).
- Any network, body-read, or parse failure falls back to cache or is skipped — an unreachable preset never blocks a run.
- Untrusted forge names (`__proto__`, `constructor`) can't match via prototype keys.
- Cycles are caught with a path-scoped visited set; diamonds still resolve on each path.
- Preset resolution is memoized per config-file path, so a monorepo resolves each config's presets once per run.

Live checks: tsdown's `.github/renovate.json5` resolves to `{exclude: ["node"]}` from the `sxzz` GitHub preset, and a gitea.com API-raw fetch round-trips through the fetcher.