### PR TITLE
Give the go major probe the same fetch deadline

### DIFF
--- a/modes/go.ts
+++ b/modes/go.ts
@@ -3,7 +3,7 @@ import {join, dirname} from "node:path";
 import {readFileSync, globSync} from "node:fs";
 import {
   type Deps, type GoProxyEntry, type ModeContext, type PackageInfo, dedupe, fieldSep, stripv, getSubDir, normalizeUrl,
-  fetchWithRetry, defaultApiUrls, getExecFile, isGoPseudoVersion, isVersionPrerelease,
+  fetchWithRetry, fetchWithDeadline, defaultApiUrls, getExecFile, isGoPseudoVersion, isVersionPrerelease,
   throwFetchError,
 } from "./shared.ts";
 import {gt, valid} from "../utils/semver.ts";
@@ -390,7 +390,10 @@ async function fetchGoProxyModule(base: string, name: string, type: string, curr
   const currentMajor = extractGoMajor(name);
   const goLatest: GoModuleFetch = (doFetch, proxy, path) => fetchGoLatestOnce(ctx, doFetch, proxy, path);
   const primaryFetch: ProxyFetch = url => fetchWithRetry(ctx, url, {headers: goProxyHeaders});
-  const probeFetch: ProxyFetch = url => ctx.doFetch(url, {signal: AbortSignal.timeout(ctx.goProbeTimeout), headers: goProxyHeaders});
+  // Probes fan out a batch at a time, so a wedged origin here parks the run just as a primary
+  // fetch would. Same deadline, the probe's own budget, and still no retry: a failed probe is a
+  // missing major, which costs nothing.
+  const probeFetch: ProxyFetch = url => fetchWithDeadline(ctx, url, {headers: goProxyHeaders}, ctx.goProbeTimeout);
   const probeWith = (fetchModule: GoModuleFetch) => async (path: string) => {
     try {
       return await fetchModule(probeFetch, base, path);

--- a/modes/shared.test.ts
+++ b/modes/shared.test.ts
@@ -21,6 +21,7 @@ import {
   fetchActionTags,
   fetchWithEtag,
   fetchWithRetry,
+  fetchWithDeadline,
   fetchImmutable,
   fetchTimeout,
   fetchRetries,
@@ -546,6 +547,12 @@ test("a fetch the runtime never settles still rejects on its own deadline", asyn
   }});
   await expect(fetchWithRetry(ctx, "https://wedged.test/x")).rejects.toThrow(/timed out after 20ms/);
   expect(attempts).toBe(fetchRetries + 1);
+});
+
+// The go major probe reaches doFetch without fetchWithRetry, so it needs the deadline of its own.
+test("a deadline applies to a probe on its own budget, not the run's", async () => {
+  const ctx = modeCtx({noCache: true, fetchTimeout: 5000, doFetch: () => new Promise<never>(() => {})});
+  await expect(fetchWithDeadline(ctx, "https://wedged.test/x", {}, 20)).rejects.toThrow(/timed out after 20ms/);
 });
 
 test("every request shares the run's one socket budget", async () => {

--- a/modes/shared.ts
+++ b/modes/shared.ts
@@ -169,19 +169,21 @@ export async function doFetch(url: string, opts?: RequestInit): Promise<Response
 // their own AbortSignal was built with, so the signal alone cannot be trusted to bound an attempt.
 const timeoutGrace = 500;
 
-async function fetchWithDeadline(ctx: ModeContext, url: string, opts: RequestInit): Promise<Response> {
+export async function fetchWithDeadline(
+  ctx: ModeContext, url: string, opts: RequestInit = {}, timeout: number = ctx.fetchTimeout,
+): Promise<Response> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
-      ctx.doFetch(url, {...opts, signal: AbortSignal.timeout(ctx.fetchTimeout)}),
+      ctx.doFetch(url, {...opts, signal: AbortSignal.timeout(timeout)}),
       // The grace lets the signal win the ordinary race and keep its own error, and is capped by
       // the timeout so a short one stays short.
       new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
-          const error = new Error(`Failed to fetch ${url}: timed out after ${ctx.fetchTimeout}ms`);
+          const error = new Error(`Failed to fetch ${url}: timed out after ${timeout}ms`);
           (error as any).transient = true; // a wedged origin is worth the same retry a socket error gets
           reject(error);
-        }, ctx.fetchTimeout + Math.min(timeoutGrace, ctx.fetchTimeout));
+        }, timeout + Math.min(timeoutGrace, timeout));
       }),
     ]);
   } finally {


### PR DESCRIPTION
Follow-up to #153, which did not fully close the stall. My validation there was wrong: I read `gh run view <id>`, which only reports the **latest** attempt, so a failure partway through a rerun sequence was invisible. Enumerating the attempts shows `attempt 7 → failure` on the merged commit.

That failure is the original signature, unchanged:

```
(fail) go [180000.23ms]
(fail) go @v/list fallback takes a date off the list line when .info is absent [180000.08ms]
(fail) fractional timeout does not throw a non-integer AbortSignal delay [180000.06ms]
(fail) go indirect with -I flag [180000.07ms]
Ran 799 tests across 18 files. [180.81s]
```

## Why #153 missed it

It put the deadline in `fetchWithRetry`. But `modes/go.ts` has two fetch paths, and only one goes through it:

```ts
const primaryFetch: ProxyFetch = url => fetchWithRetry(ctx, url, {headers: goProxyHeaders});
const probeFetch:   ProxyFetch = url => ctx.doFetch(url, {signal: AbortSignal.timeout(ctx.goProbeTimeout), ...});
```

`probeFetch` was the only remaining caller reaching `doFetch` directly, so it kept just its `AbortSignal` — precisely what the runtime fails to honour on a saturated origin. It also fans out a batch of majors at a time, which is what saturates the origin, making it the likelier half to park the run. That explains why go tests were always the most frequent victims.

## Fix

`fetchWithDeadline` is exported and takes an explicit timeout, so the probe uses it on `goProbeTimeout`. Its no-retry, no-slot behaviour is unchanged: a failed probe is a missing major, which costs nothing.

`grep` for `ctx.doFetch` now returns only the two call sites inside `fetchWithDeadline` itself, so no path is left unbounded.

## Validation

I will enumerate `runs/<id>/attempts/<n>` this time rather than trusting the latest-attempt view.

Written by Claude.