### PR TITLE
Serve the mock registries without awaiting mid-request

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -6,7 +6,7 @@ import {writeFile, readFile, rm} from "node:fs/promises";
 import {fileURLToPath} from "node:url";
 import {tmpdir} from "node:os";
 import {execPath, platform, versions} from "node:process";
-import {gzip, constants} from "node:zlib";
+import {gzip, gzipSync, constants} from "node:zlib";
 import {promisify} from "node:util";
 import type {Server} from "node:http";
 import {satisfies} from "./utils/semver.ts";
@@ -32,6 +32,10 @@ globalThis.fetch = ((input: any, init?: any) => {
 
 const globalExpect = expect;
 const gzipPromise = (data: string | Buffer) => promisify(gzip)(data, {level: constants.Z_BEST_SPEED});
+// Request handlers compress synchronously: zlib's async form runs on the libuv threadpool, so a
+// saturated pool leaves a handler awaiting mid-request and the client waiting on a response that
+// never comes. Sync also makes memoizing a route's buffer atomic, where check-then-await raced.
+const gzipNow = (data: string | Buffer) => gzipSync(data, {level: constants.Z_BEST_SPEED});
 const testFile = fileURLToPath(new URL("fixtures/npm-test/package.json", import.meta.url));
 const emptyFile = fileURLToPath(new URL("fixtures/npm-empty/package.json", import.meta.url));
 const jsrFile = fileURLToPath(new URL("fixtures/npm-jsr/package.json", import.meta.url));
@@ -63,7 +67,9 @@ const testPkg = JSON.parse(readFileSync(testFile, "utf8"));
 const testDir = mkdtempSync(join(tmpdir(), "updates-"));
 const script = fileURLToPath(new URL("dist/index.js", import.meta.url));
 
-type RouteHandler = (req: any, res: any) => void | Promise<void>;
+// Synchronous by type: an awaiting handler holds the request open on whatever it waits for,
+// which the client can only see as a response that never arrives.
+type RouteHandler = (req: any, res: any) => void;
 
 function isObject<T = Record<string, any>>(obj: any): obj is T {
   return Object.prototype.toString.call(obj) === "[object Object]";
@@ -72,7 +78,7 @@ function isObject<T = Record<string, any>>(obj: any): obj is T {
 function makeServer(defaultHandler: RouteHandler) {
   const routes = new Map<string, RouteHandler>();
 
-  const server = createServer(async (req, res) => {
+  const server = createServer((req, res) => {
     const url = (req.url || "/").split("?")[0];
     const handler = routes.get(url) || defaultHandler;
 
@@ -82,7 +88,7 @@ function makeServer(defaultHandler: RouteHandler) {
     };
 
     try {
-      await handler(req, res);
+      handler(req, res);
     } catch (err) {
       res.statusCode = 500;
       res.end(String(err)); // an Error makes end() throw, leaving the client to stall until its timeout
@@ -203,18 +209,16 @@ beforeAll(async () => {
   const abbreviatedType = "application/vnd.npm.install-v1+json";
   for (const {urlName} of npmFiles) {
     // gzip lazily and per flavor: only a --cooldown run ever asks for the dated document
-    const gzips = new Map<string, Promise<Buffer>>();
-    npmServer.get(`/${urlName}`, async (req, res) => {
+    const gzips = new Map<string, Buffer>();
+    npmServer.get(`/${urlName}`, (req, res) => {
       const flavor = req.headers.accept?.includes(abbreviatedType) ? "abbrev" : "full";
       let gz = gzips.get(flavor);
       if (!gz) {
-        gzips.set(flavor, gz = (async () => {
-          const doc = {...npmParsed.get(urlName)};
-          if (flavor === "abbrev") delete doc.time;
-          return gzipPromise(JSON.stringify(doc));
-        })());
+        const doc = {...npmParsed.get(urlName)};
+        if (flavor === "abbrev") delete doc.time;
+        gzips.set(flavor, gz = gzipNow(JSON.stringify(doc)));
       }
-      res.send(await gz);
+      res.send(gz);
     });
   }
 
@@ -236,10 +240,10 @@ beforeAll(async () => {
     const time = data.time || {};
     for (const version of Object.keys(versions)) {
       let gz: Buffer | undefined;
-      npmServer.get(`/${urlName}/${version}`, async (_, res) => {
+      npmServer.get(`/${urlName}/${version}`, (_, res) => {
         if (!gz) {
           const vData = {...versions[version], _npmOperationalInternal: {tmp: `tmp/${urlName}_${version}_${Date.parse(time[version] || "2024-01-01") || 0}_0`}};
-          gz = await gzipPromise(JSON.stringify(vData));
+          gz = gzipNow(JSON.stringify(vData));
         }
         res.send(gz);
       });
@@ -2200,7 +2204,7 @@ test("api basic", async ({expect = globalExpect}: any = {}) => {
 
   // a second call in the same process re-requests rather than answering from the finished run's cache
   let latest = "3.1.4";
-  const registry = makeServer(async (_, res) => res.send(await gzipPromise(JSON.stringify({
+  const registry = makeServer((_, res) => res.send(gzipNow(JSON.stringify({
     name: "noty", "dist-tags": {latest}, versions: {"3.1.0": {}, "3.1.4": {}, "3.2.1": {}},
   }))));
   await registry.start(0);


### PR DESCRIPTION
The actual cause of the intermittent stall, found by instrumenting the mock server rather than the client.

## Evidence

```
[server-stuck] npm /typescript/5.4.5 unanswered for 89611ms
[server] npm     received=200 responded=199 inflight=1 stuck=1
[server] goProxy received=267 responded=267 inflight=0 stuck=0
```

The request **reached the server**. The handler was entered and never responded — one request stuck for the full run while every other origin drained clean. All 16 failing tests in that run were waiting on that single wedged handler.

That reframes #153 and #154: those bound the symptom on the client, correctly and worth keeping, but the fault was here.

## Cause

Three route handlers `await`ed `gzipPromise` mid-request. `zlib`'s async form runs on the libuv threadpool (4 threads by default), so under enough concurrent compression a handler sits awaiting while holding the request open. The client sees only a response that never arrives. A CI runner with few cores hits this; my machine never did across dozens of local runs.

The same handlers also had a check-then-await race:

```ts
if (!gz) { gz = await gzipPromise(...); }   // two requests both miss, both compress
```

## Fix

Compress with `gzipSync` in handlers. No new dependency — `gzipSync` is `node:zlib`, already imported. Setup-time compression keeps using the async form, where there is no request held open and no concurrency to lose.

Synchronous compression also makes the memoization atomic, removing the duplicate-work race for free.

`RouteHandler` now returns `void` rather than `void | Promise<void>`, so a handler cannot reintroduce the await. `createServer`'s wrapper is synchronous to match, and its try/catch still covers a throwing handler.

Suite runtime is unchanged at ~1.2s; these documents are small and each route compresses once.

Written by Claude.