### PR TITLE
Give ModeContext a subprocess seam, as it has for the network

### DIFF
--- a/modes/go.test.ts
+++ b/modes/go.test.ts
@@ -357,13 +357,17 @@ test("fetchGoProxyInfo falls through a `|` list on a proxy failure", async () =>
   expect(data.new).toBe("1.2.0");
 });
 
-// `direct` routes to a VCS lookup the 1ms timeout kills, and neither token may reach a proxy.
+// `direct` routes to a VCS lookup, and neither token may reach a proxy. The lookup runs against the
+// context's own execFile, so no `go` is spawned: the real one reaches the network for an unreachable
+// module and then has to be killed mid-run, which is slow, needs a toolchain, and leaves the failure
+// text up to whichever `go` is installed.
 test.each([
   ["off", ".", /disabled by GOPROXY=off/],
-  ["direct", resolve("."), /go list -m github.com\/foo\/bar@latest failed/],
+  ["direct", resolve("."), /go list -m github.com\/foo\/bar@latest failed: no such host/],
 ])("fetchGoProxyInfo fails without contacting a proxy for GOPROXY=%s", async (value, cwd, message) => {
   const seen: Array<string> = [];
-  const ctx = {...makeGoCtx({}, seen, parseGoProxy(value)), fetchTimeout: 1, goProbeTimeout: 1};
+  const execFile = () => Promise.reject(Object.assign(new Error("Command failed"), {stderr: "no such host"}));
+  const ctx = {...makeGoCtx({}, seen, parseGoProxy(value)), execFile};
   await expect(infoFor(ctx, cwd)).rejects.toThrow(message);
   expect(seen).toEqual([]);
 });

--- a/modes/go.ts
+++ b/modes/go.ts
@@ -3,7 +3,7 @@ import {join, dirname} from "node:path";
 import {readFileSync, globSync} from "node:fs";
 import {
   type Deps, type GoProxyEntry, type ModeContext, type PackageInfo, dedupe, fieldSep, stripv, getSubDir, normalizeUrl,
-  fetchWithRetry, defaultApiUrls, getExecFile, isGoPseudoVersion, isVersionPrerelease,
+  fetchWithRetry, defaultApiUrls, execFileFor, isGoPseudoVersion, isVersionPrerelease,
   throwFetchError,
 } from "./shared.ts";
 import {gt, valid} from "../utils/semver.ts";
@@ -279,7 +279,7 @@ async function fetchGoVcsInfo(name: string, type: string, currentVersion: string
   // `go list` with the same exit, and nothing follows `direct`, so any failure is the dep's error.
   const goListQuery = async (modulePath: string, timeout: number): Promise<ProbeResult> => {
     try {
-      const execFile = await getExecFile();
+      const execFile = await execFileFor(ctx);
       const {stdout} = await execFile("go", ["list", "-m", "-json", `${modulePath}@latest`], {timeout, cwd: goCwd, env});
       const data = JSON.parse(stdout) as {Version: string, Time?: string};
       return {Version: data.Version, Time: data.Time || "", path: modulePath};

--- a/modes/make.ts
+++ b/modes/make.ts
@@ -1,5 +1,5 @@
 import {env} from "node:process";
-import {type ModeContext, stripv, formatVersionPrecision, findNewVersion, getExecFile, fetchWithRetry} from "./shared.ts";
+import {type ModeContext, stripv, formatVersionPrecision, findNewVersion, execFileFor, fetchWithRetry} from "./shared.ts";
 import {longestFirstAlternation, tryOrNull} from "../utils/utils.ts";
 import {goModulePathForVersion, fetchGoLatestOnce, fetchGoProxyInfo, getGoInfoUrl, isGoNoProxy, goProxyHeaders} from "./go.ts";
 import {
@@ -101,7 +101,7 @@ export function moduleRootFromMajor(installPath: string): string | null {
 // address whose failure would silently drop every tool in the file.
 async function probeGoModuleRoot(candidate: string, goCwd: string, ctx: ModeContext, useVcs: boolean): Promise<boolean> {
   if (useVcs) {
-    const execFile = await getExecFile();
+    const execFile = await execFileFor(ctx);
     // `go list` exits non-zero for a path that is no module and for an unreachable host alike.
     return await tryOrNull(execFile("go", ["list", "-m", "-json", `${candidate}@latest`], {timeout: ctx.fetchTimeout, cwd: goCwd, env})) !== null;
   }

--- a/modes/shared.ts
+++ b/modes/shared.ts
@@ -98,8 +98,16 @@ export type ModeContext = {
   cratesIoUrl: string,
   dockerApiUrl: string,
   doFetch: typeof doFetch,
+  /** Subprocess seam, as `doFetch` is for the network: a test supplies its own rather than
+   * spawning a real `go`. Absent outside tests, where the real one is loaded lazily. */
+  execFile?: ExecFile,
   noCache: boolean,
 };
+
+/** The promisified `child_process.execFile` shape the go and make modes call. */
+export type ExecFile = (
+  file: string, args: Array<string>, opts: Record<string, any>,
+) => Promise<{stdout: string, stderr: string}>;
 
 export const packageVersion = pkg.version;
 export const fieldSep = "\0";
@@ -556,6 +564,11 @@ async function loadExecFile() {
   ]);
   return promisify(execFile);
 }
+// A context's own seam wins, so a test never reaches child_process at all.
+export function execFileFor(ctx: ModeContext): ExecFile | Promise<ExecFile> {
+  return ctx.execFile ?? getExecFile();
+}
+
 export function getExecFile() {
   return execFilePromise ??= loadExecFile();
 }


### PR DESCRIPTION
No workaround: this removes the thing that was tripping the runtime, and leaves the test suite better for it.

## The problem

`ModeContext.doFetch` exists so a test never reaches the network. Nothing played that part for `go list`, so the VCS-fallback test spawned a **real** `go`, which resolves an unreachable module over the network — 3s locally, mostly spent in `git ls-remote`. To stay fast the test set `fetchTimeout: 1`, so node SIGTERMed the child after 1ms.

That is three problems in one unit test:

1. it needs a Go toolchain installed
1. it hides seconds of network wall time behind a kill
1. it asserts against whatever failure text the locally installed `go` prints

And a fourth, which is what brought me here: it tears a child process down while the rest of the suite has requests in flight. Bun 1.3.14 responds to subprocess teardown by closing an fd belonging to a live connection, hanging an unrelated in-process fetch — oven-sh/bun#37230, confirmed by the maintainer and fixed on main, but **not in any released build** (1.3.14 is current, and our CI pins `bun-version: latest`).

## The change

`ModeContext` gains an optional `execFile`, mirroring `doFetch`, and `execFileFor(ctx)` prefers it over the lazily-loaded real one. `go.ts` and `make.ts` both route through it.

The test supplies its own, so no `go` is spawned. Verified by running `modes/go.test.ts` with no `go` on `PATH` at all: 58/58 pass in 20ms, where the spawning version needed a toolchain and ~3s of network per case.

## Why this and not a workaround

I had a workaround ready — a malformed module path that makes `go` fail during parsing instead of over the network. It would have dodged the bun bug too, but it left the test spawning a subprocess, needing a toolchain, and asserting on someone else's error string. The seam fixes the actual design gap: the network already had one, subprocesses didn't.

Written by Claude.