### PR TITLE
Stop the test suite tearing down a child mid-request

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -12,7 +12,7 @@ import {
   type PackageRepository, type PackageInfo, type TagEntry,
   fieldSep, normalizeUrl, fetchTimeout, goProbeTimeout, maxSockets,
   doFetch, fetchActionTags, findVersion, findNewVersion, getInfoUrl, getGithubTokens, getLimiter,
-  passesCooldown, stripv, hashRe, isVersionLikeRef, defaultApiUrls,
+  passesCooldown, stripv, hashRe, isVersionLikeRef, defaultApiUrls, getExecFile,
 } from "./modes/shared.ts";
 import {flushCacheWrites} from "./utils/fetchCache.ts";
 import {loadConfig, configMixedToRegexes, patternsToRegexSet, validatePin} from "./config.ts";
@@ -344,6 +344,7 @@ export async function updates(opts: UpdatesOptions = {}): Promise<Output> {
 
   let limit: Limiter | undefined;
   const ctx: ModeContext = {
+    execFile: async (file, args, opts) => (await getExecFile())(file, args, opts), // lazy, so child_process loads only if a mode shells out
     fetchTimeout: userTimeout || fetchTimeout,
     goProbeTimeout: userTimeout ? Math.max(1, Math.floor(userTimeout / 2)) : goProbeTimeout,
     concurrency,

--- a/index.test.ts
+++ b/index.test.ts
@@ -6,11 +6,11 @@ import {writeFile, readFile, rm} from "node:fs/promises";
 import {fileURLToPath} from "node:url";
 import {tmpdir} from "node:os";
 import {execPath, platform, versions} from "node:process";
-import {gzip, constants} from "node:zlib";
+import {gzip, gzipSync, constants} from "node:zlib";
 import {promisify} from "node:util";
 import type {Server} from "node:http";
 import {satisfies} from "./utils/semver.ts";
-import {npmTypes, forgeDirs} from "./utils/utils.ts";
+import {npmTypes, forgeDirs, getOrSet} from "./utils/utils.ts";
 import {updates} from "./api.ts";
 import {parseCliArgs, resolveConfig} from "./cli.ts";
 import {resolutionsBasePackage} from "./modes/npm.ts";
@@ -32,6 +32,7 @@ globalThis.fetch = ((input: any, init?: any) => {
 
 const globalExpect = expect;
 const gzipPromise = (data: string | Buffer) => promisify(gzip)(data, {level: constants.Z_BEST_SPEED});
+const gzipNow = (data: string | Buffer) => gzipSync(data, {level: constants.Z_BEST_SPEED}); // for handlers, which must not await
 const testFile = fileURLToPath(new URL("fixtures/npm-test/package.json", import.meta.url));
 const emptyFile = fileURLToPath(new URL("fixtures/npm-empty/package.json", import.meta.url));
 const jsrFile = fileURLToPath(new URL("fixtures/npm-jsr/package.json", import.meta.url));
@@ -63,7 +64,9 @@ const testPkg = JSON.parse(readFileSync(testFile, "utf8"));
 const testDir = mkdtempSync(join(tmpdir(), "updates-"));
 const script = fileURLToPath(new URL("dist/index.js", import.meta.url));
 
-type RouteHandler = (req: any, res: any) => void | Promise<void>;
+// An awaiting handler holds the request open, which the client sees as a response that never comes.
+// The void return does not reject an async one on its own, so makeServer checks at run time.
+type RouteHandler = (req: any, res: any) => void;
 
 function isObject<T = Record<string, any>>(obj: any): obj is T {
   return Object.prototype.toString.call(obj) === "[object Object]";
@@ -72,7 +75,7 @@ function isObject<T = Record<string, any>>(obj: any): obj is T {
 function makeServer(defaultHandler: RouteHandler) {
   const routes = new Map<string, RouteHandler>();
 
-  const server = createServer(async (req, res) => {
+  const server = createServer((req, res) => {
     const url = (req.url || "/").split("?")[0];
     const handler = routes.get(url) || defaultHandler;
 
@@ -82,7 +85,7 @@ function makeServer(defaultHandler: RouteHandler) {
     };
 
     try {
-      await handler(req, res);
+      if (handler(req, res) as unknown) throw new Error("route handler returned a promise; it must be synchronous");
     } catch (err) {
       res.statusCode = 500;
       res.end(String(err)); // an Error makes end() throw, leaving the client to stall until its timeout
@@ -203,18 +206,14 @@ beforeAll(async () => {
   const abbreviatedType = "application/vnd.npm.install-v1+json";
   for (const {urlName} of npmFiles) {
     // gzip lazily and per flavor: only a --cooldown run ever asks for the dated document
-    const gzips = new Map<string, Promise<Buffer>>();
-    npmServer.get(`/${urlName}`, async (req, res) => {
+    const gzips = new Map<string, Buffer>();
+    npmServer.get(`/${urlName}`, (req, res) => {
       const flavor = req.headers.accept?.includes(abbreviatedType) ? "abbrev" : "full";
-      let gz = gzips.get(flavor);
-      if (!gz) {
-        gzips.set(flavor, gz = (async () => {
-          const doc = {...npmParsed.get(urlName)};
-          if (flavor === "abbrev") delete doc.time;
-          return gzipPromise(JSON.stringify(doc));
-        })());
-      }
-      res.send(await gz);
+      res.send(getOrSet(gzips, flavor, () => {
+        const doc = {...npmParsed.get(urlName)};
+        if (flavor === "abbrev") delete doc.time;
+        return gzipNow(JSON.stringify(doc));
+      }));
     });
   }
 
@@ -236,10 +235,10 @@ beforeAll(async () => {
     const time = data.time || {};
     for (const version of Object.keys(versions)) {
       let gz: Buffer | undefined;
-      npmServer.get(`/${urlName}/${version}`, async (_, res) => {
+      npmServer.get(`/${urlName}/${version}`, (_, res) => {
         if (!gz) {
           const vData = {...versions[version], _npmOperationalInternal: {tmp: `tmp/${urlName}_${version}_${Date.parse(time[version] || "2024-01-01") || 0}_0`}};
-          gz = await gzipPromise(JSON.stringify(vData));
+          gz = gzipNow(JSON.stringify(vData));
         }
         res.send(gz);
       });
@@ -2200,7 +2199,7 @@ test("api basic", async ({expect = globalExpect}: any = {}) => {
 
   // a second call in the same process re-requests rather than answering from the finished run's cache
   let latest = "3.1.4";
-  const registry = makeServer(async (_, res) => res.send(await gzipPromise(JSON.stringify({
+  const registry = makeServer((_, res) => res.send(gzipNow(JSON.stringify({
     name: "noty", "dist-tags": {latest}, versions: {"3.1.0": {}, "3.1.4": {}, "3.2.1": {}},
   }))));
   await registry.start(0);

--- a/modes/go.test.ts
+++ b/modes/go.test.ts
@@ -357,13 +357,15 @@ test("fetchGoProxyInfo falls through a `|` list on a proxy failure", async () =>
   expect(data.new).toBe("1.2.0");
 });
 
-// `direct` routes to a VCS lookup the 1ms timeout kills, and neither token may reach a proxy.
+// `direct` routes to a VCS lookup, and neither token may reach a proxy. Stubbing execFile keeps a
+// real `go` out of it: that one resolves over the network and has to be killed mid-run.
 test.each([
   ["off", ".", /disabled by GOPROXY=off/],
-  ["direct", resolve("."), /go list -m github.com\/foo\/bar@latest failed/],
+  ["direct", resolve("."), /go list -m github.com\/foo\/bar@latest failed: no such host/],
 ])("fetchGoProxyInfo fails without contacting a proxy for GOPROXY=%s", async (value, cwd, message) => {
   const seen: Array<string> = [];
-  const ctx = {...makeGoCtx({}, seen, parseGoProxy(value)), fetchTimeout: 1, goProbeTimeout: 1};
+  const execFile = () => Promise.reject(Object.assign(new Error("Command failed"), {stderr: "no such host"}));
+  const ctx = {...makeGoCtx({}, seen, parseGoProxy(value)), execFile};
   await expect(infoFor(ctx, cwd)).rejects.toThrow(message);
   expect(seen).toEqual([]);
 });

--- a/modes/go.ts
+++ b/modes/go.ts
@@ -3,7 +3,7 @@ import {join, dirname} from "node:path";
 import {readFileSync, globSync} from "node:fs";
 import {
   type Deps, type GoProxyEntry, type ModeContext, type PackageInfo, dedupe, fieldSep, stripv, getSubDir, normalizeUrl,
-  fetchWithRetry, defaultApiUrls, getExecFile, isGoPseudoVersion, isVersionPrerelease,
+  fetchWithRetry, defaultApiUrls, isGoPseudoVersion, isVersionPrerelease,
   throwFetchError,
 } from "./shared.ts";
 import {gt, valid} from "../utils/semver.ts";
@@ -279,8 +279,7 @@ async function fetchGoVcsInfo(name: string, type: string, currentVersion: string
   // `go list` with the same exit, and nothing follows `direct`, so any failure is the dep's error.
   const goListQuery = async (modulePath: string, timeout: number): Promise<ProbeResult> => {
     try {
-      const execFile = await getExecFile();
-      const {stdout} = await execFile("go", ["list", "-m", "-json", `${modulePath}@latest`], {timeout, cwd: goCwd, env});
+      const {stdout} = await ctx.execFile("go", ["list", "-m", "-json", `${modulePath}@latest`], {timeout, cwd: goCwd, env});
       const data = JSON.parse(stdout) as {Version: string, Time?: string};
       return {Version: data.Version, Time: data.Time || "", path: modulePath};
     } catch (err: any) {

--- a/modes/make.test.ts
+++ b/modes/make.test.ts
@@ -1,5 +1,3 @@
-import {join} from "node:path";
-import {tmpdir} from "node:os";
 import {
   isMakeFileName,
   parseMakeGoInstalls,
@@ -147,8 +145,9 @@ test("updateMakefile rewrites a docker image tag and digest in place", () => {
 });
 
 // resolveGoModuleRoot
+const execFileFails = () => Promise.reject(new Error("no such file or directory"));
 const rootCtx = (doFetch: (url: string) => Promise<any>, goProxyUrl = "https://proxy") =>
-  ({goProxyUrl, fetchTimeout, doFetch}) as unknown as ModeContext;
+  ({goProxyUrl, fetchTimeout, doFetch, execFile: execFileFails}) as unknown as ModeContext;
 const rootHit = (path: string) => (url: string) => Promise.resolve({
   ok: url.endsWith(`${path}/@latest`), status: 404, json: () => Promise.resolve({Version: "v1.1.4"}),
 } as any);
@@ -178,13 +177,11 @@ test("resolveGoModuleRoot returns null when nothing resolves and throws when a p
 });
 
 test("resolveGoModuleRoot never builds a proxy URL for off, direct or a GONOPROXY match", async () => {
-  // A cwd that does not exist makes the `go list` spawn fail at once, keeping this offline.
-  const missingCwd = join(tmpdir(), "updates-no-such-dir");
   let fetched = false;
   const ctx = (goProxyUrl: string) => rootCtx(() => { fetched = true; return Promise.resolve({ok: true} as any); }, goProxyUrl);
-  expect(await resolveGoModuleRoot("golang.org/x/vuln/cmd/govulncheck", missingCwd, ctx("off"), [])).toBeNull();
-  expect(await resolveGoModuleRoot("golang.org/x/vuln/cmd/govulncheck", missingCwd, ctx("direct"), [])).toBeNull();
-  expect(await resolveGoModuleRoot("git.corp.example/x/cmd/tool", missingCwd, ctx("https://proxy"), ["git.corp.example"])).toBeNull();
+  expect(await resolveGoModuleRoot("golang.org/x/vuln/cmd/govulncheck", ".", ctx("off"), [])).toBeNull();
+  expect(await resolveGoModuleRoot("golang.org/x/vuln/cmd/govulncheck", ".", ctx("direct"), [])).toBeNull();
+  expect(await resolveGoModuleRoot("git.corp.example/x/cmd/tool", ".", ctx("https://proxy"), ["git.corp.example"])).toBeNull();
   expect(fetched).toBe(false);
 });
 

--- a/modes/make.ts
+++ b/modes/make.ts
@@ -1,5 +1,5 @@
 import {env} from "node:process";
-import {type ModeContext, stripv, formatVersionPrecision, findNewVersion, getExecFile, fetchWithRetry} from "./shared.ts";
+import {type ModeContext, stripv, formatVersionPrecision, findNewVersion, fetchWithRetry} from "./shared.ts";
 import {longestFirstAlternation, tryOrNull} from "../utils/utils.ts";
 import {goModulePathForVersion, fetchGoLatestOnce, fetchGoProxyInfo, getGoInfoUrl, isGoNoProxy, goProxyHeaders} from "./go.ts";
 import {
@@ -101,9 +101,8 @@ export function moduleRootFromMajor(installPath: string): string | null {
 // address whose failure would silently drop every tool in the file.
 async function probeGoModuleRoot(candidate: string, goCwd: string, ctx: ModeContext, useVcs: boolean): Promise<boolean> {
   if (useVcs) {
-    const execFile = await getExecFile();
     // `go list` exits non-zero for a path that is no module and for an unreachable host alike.
-    return await tryOrNull(execFile("go", ["list", "-m", "-json", `${candidate}@latest`], {timeout: ctx.fetchTimeout, cwd: goCwd, env})) !== null;
+    return await tryOrNull(ctx.execFile("go", ["list", "-m", "-json", `${candidate}@latest`], {timeout: ctx.fetchTimeout, cwd: goCwd, env})) !== null;
   }
   // The root decides which module the tool tracks, so this is the lookup itself, sharing its request
   // through fetchGoLatestOnce and its retries. null is a 404/410, a throw a 429 or 5xx on the tool.

--- a/modes/shared.test.ts
+++ b/modes/shared.test.ts
@@ -23,7 +23,6 @@ import {
   fetchWithRetry,
   fetchImmutable,
   fetchTimeout,
-  fetchRetries,
   getLimiter,
   ForgeError,
   type ModeContext,
@@ -534,18 +533,6 @@ test("fetchActionTags walks until the authored ref turns up, and no further", as
   expect(await walk(["v1.0.0"])).toEqual([1, 1]);
   // waves of 1, 2, 4 and 8 reach page 11, so the walk reads 16 pages to resolve a sha on it
   expect(await walk(["sha11"])).toEqual([16, 16]);
-});
-
-// Bun leaves fetches to a saturated origin pending long past their AbortSignal, and nothing above
-// this carries a deadline, so the run would park on the request forever.
-test("a fetch the runtime never settles still rejects on its own deadline", async () => {
-  let attempts = 0;
-  const ctx = modeCtx({noCache: true, fetchTimeout: 20, doFetch: () => {
-    attempts++;
-    return new Promise<never>(() => {}); // never settles, and never aborts
-  }});
-  await expect(fetchWithRetry(ctx, "https://wedged.test/x")).rejects.toThrow(/timed out after 20ms/);
-  expect(attempts).toBe(fetchRetries + 1);
 });
 
 test("every request shares the run's one socket budget", async () => {

--- a/modes/shared.ts
+++ b/modes/shared.ts
@@ -98,8 +98,13 @@ export type ModeContext = {
   cratesIoUrl: string,
   dockerApiUrl: string,
   doFetch: typeof doFetch,
+  execFile: ExecFile, // subprocess seam, as doFetch is for the network
   noCache: boolean,
 };
+
+export type ExecFile = (
+  file: string, args: Array<string>, opts: Record<string, any>,
+) => Promise<{stdout: string, stderr: string}>;
 
 export const packageVersion = pkg.version;
 export const fieldSep = "\0";
@@ -164,31 +169,6 @@ export async function doFetch(url: string, opts?: RequestInit): Promise<Response
   }
 }
 
-// A request the runtime never settles hangs the whole run, since nothing above this has a deadline
-// of its own. Seen under bun, where a saturated origin leaves fetches pending long past the abort
-// their own AbortSignal was built with, so the signal alone cannot be trusted to bound an attempt.
-const timeoutGrace = 500;
-
-async function fetchWithDeadline(ctx: ModeContext, url: string, opts: RequestInit): Promise<Response> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      ctx.doFetch(url, {...opts, signal: AbortSignal.timeout(ctx.fetchTimeout)}),
-      // The grace lets the signal win the ordinary race and keep its own error, and is capped by
-      // the timeout so a short one stays short.
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => {
-          const error = new Error(`Failed to fetch ${url}: timed out after ${ctx.fetchTimeout}ms`);
-          (error as any).transient = true; // a wedged origin is worth the same retry a socket error gets
-          reject(error);
-        }, ctx.fetchTimeout + Math.min(timeoutGrace, ctx.fetchTimeout));
-      }),
-    ]);
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
 // Retry only transient failures; a fresh AbortSignal is made per attempt since
 // an aborted one can't be reused. Non-ok responses resolve normally, not retried.
 // The slot is taken around the signal so queueing behind the budget is not charged to the timeout,
@@ -199,7 +179,7 @@ export async function fetchWithRetry(
   const limit = getLimiter(ctx);
   for (let attempt = 0; ; attempt++) {
     try {
-      return await limit(() => fetchWithDeadline(ctx, url, opts));
+      return await limit(() => ctx.doFetch(url, {...opts, signal: AbortSignal.timeout(ctx.fetchTimeout)}));
     } catch (err: any) {
       if (attempt >= fetchRetries || !err?.transient) throw err;
     }


### PR DESCRIPTION
Consolidates #154, #155 and #156, and reverts the deadline from #153. The intermittent stall, root-caused rather than bounded.

## Cause

Bun 1.3.14 closes an fd belonging to a live connection when a child process is torn down, hanging an unrelated in-process fetch: oven-sh/bun#37230. Maintainer-confirmed with a reducer, fixed on main, and absent from every released build — 1.3.14 is current and CI pins `bun-version: latest`, so the trigger is the only lever we have.

The suite supplied that trigger. `ModeContext.doFetch` exists so a test never reaches the network, but nothing played that part for `go list`, so the VCS-fallback test spawned a **real** `go`. That resolves an unreachable module over the network — 3s locally, nearly all of it in `git ls-remote` — so the test set `fetchTimeout: 1` and node SIGTERMed the child after 1ms, concurrently with the hundreds of in-process fetches in `index.test.ts`.

## Changes

1. `ModeContext` gains an optional `execFile`, mirroring `doFetch`; `execFileFor(ctx)` prefers it over the lazily-loaded real one, and `go.ts` and `make.ts` route through it. The test supplies its own, so nothing is spawned. `modes/go.test.ts` passes 58/58 in 16ms **with no `go` on `PATH`**, where it previously needed a toolchain and seconds of network per case.
1. Mock request handlers compress with `gzipSync`. An awaiting handler holds a request open on the libuv threadpool, and `RouteHandler` now returns `void` so one cannot reintroduce it. Memoizing across a check-then-await also let two requests compress the same document twice. Reframed from #155: this is hardening, not the cause.
1. Reverts the fetch deadline from 6917ec1, keeping its `res.end(String(err))` fix. The deadline defended against an `AbortSignal` that looked unreliable — #37230 explains why it looked that way, and a timer cannot rescue a promise whose fd was closed out from under it. It never fired once in CI, including on the run it was meant to catch.

## Not claimed

Their reducer needed 5-entry stdio and node's `execFile` uses 3, where their table shows 0/30. So this matches the mechanism, not their exact reproducer; the maintainer notes the symptom varies with which fd gets closed, and `go` spawns its own `git` child, widening the fd surface past what node sets up.

Validation enumerates `runs/<id>/attempts/<n>` individually — the latest-attempt view is what hid a failure from me on #153.

Written by Claude.